### PR TITLE
docs: add 'What dd-agents does NOT do' section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,80 +26,22 @@ dd-agents run deal-config.json
 
 ## What dd-agents does (and does not) do
 
-dd-agents is a forensic analysis accelerator for M&A due diligence. It:
+dd-agents is a **forensic analysis accelerator** for M&A due diligence — it gets your team and advisors to the connected picture faster, with every claim traceable to the source.
 
-- Reads an entire data room across 9 domains and cross-references findings no single reviewer connects
-- Traces every finding to an exact page and verbatim quote
-- **Accelerates** legal/financial advisors — it does **not** replace them
-- Provides analysis used as a basis for deliverables (not a final "board-ready" document)
-- Runs locally; documents only leave as API calls to your own LLM provider
+**It does:**
 
-**It does not**:
+- Read an entire data room across 9 domains and **cross-reference** findings no single-domain reviewer connects.
+- Trace every finding to an exact page and verbatim quote, so each conclusion is auditable.
+- Halt rather than ship unverified output — quality gates are fail-closed, not advisory.
+- Run locally: documents only leave your machine as API calls to your own LLM provider (Anthropic or AWS Bedrock).
+- Produce structured output (interactive HTML, Excel, JSON) you use as a **basis** for IC memos, advisor reports, and negotiation checklists.
 
-- Operate without human oversight — quality gates halt rather than ship unverified output
-- Guarantee zero hallucinations (human review remains essential)
-- Replace professional advisors or provide legal/financial/regulatory conclusions
+**It does not:**
 
-
-## Install Options
-
-=== "pip (recommended)"
-
-    ```bash
-    pip install dd-agents[pdf]
-    ```
-
-=== "pipx (isolated CLI)"
-
-    ```bash
-    pipx install dd-agents[pdf]
-    ```
-
-=== "Homebrew (macOS)"
-
-    ```bash
-    brew install zoharbabin/due-diligence-agents/dd-agents
-    ```
-
-=== "Docker"
-
-    ```bash
-    docker pull zoharbabin/due-diligence-agents:latest
-    docker run -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
-      -v ./data_room:/data zoharbabin/due-diligence-agents run /data/deal-config.json
-    ```
-
-## Next Steps
-
-- [Getting Started](user-guide/getting-started.md) — full installation and first-run walkthrough
-- [Deal Configuration](user-guide/deal-configuration.md) — customize analysis focus areas
-- [CLI Reference](user-guide/cli-reference.md) — every command, flag, and exit code
-- [Contract Search Guide](search-guide.md) — targeted search without the full pipeline
-# DD-Agents — Forensic M&A Due Diligence
-
-**Legal flags a risk. Finance flags another. We connect and cite.** Open-source forensic M&A due diligence — 13 AI agents read your entire data room across 9 specialist domains, cross-reference the findings no single reviewer connects, and trace every one to an exact page and verbatim quote. Quality-gated HTML + Excel reports.
-
-## Quick Start
-
-```bash
-pip install dd-agents[pdf]
-export ANTHROPIC_API_KEY="sk-ant-..."
-dd-agents init --data-room ./your_data_room
-dd-agents run deal-config.json
-```
-
-**[See a sample report →](https://zoharbabin.github.io/due-diligence-agents/sample-report/)**
-
-## What It Does
-
-| Command | Purpose |
-|---------|---------|
-| `dd-agents run` | Full 38-step pipeline across 9 domains |
-| `dd-agents run --quick-scan` | Red flag triage in minutes |
-| `dd-agents search` | Targeted contract questions with citations |
-| `dd-agents chat` | Interactive multi-turn chat about findings |
-| `dd-agents query` | Single-question mode |
-| `dd-agents assess` | Data room quality check |
+- Replace qualified legal, financial, tax, or regulatory advisors — it **accelerates** them; humans make the conclusions.
+- Operate without human oversight, or claim to be a final, sign-off-ready deliverable.
+- Guarantee a model never errs — the value is that findings are **cited and checkable**, and the pipeline stops rather than emit a claim it cannot ground.
+- Send your data room anywhere beyond your configured LLM provider, or store credentials in its output.
 
 ## Install Options
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,83 @@ dd-agents run deal-config.json
 | `dd-agents query` | Single-question mode |
 | `dd-agents assess` | Data room quality check |
 
+## What dd-agents does (and does not) do
+
+dd-agents is a forensic analysis accelerator for M&A due diligence. It:
+
+- Reads an entire data room across 9 domains and cross-references findings no single reviewer connects
+- Traces every finding to an exact page and verbatim quote
+- **Accelerates** legal/financial advisors — it does **not** replace them
+- Provides analysis used as a basis for deliverables (not a final "board-ready" document)
+- Runs locally; documents only leave as API calls to your own LLM provider
+
+**It does not**:
+
+- Operate without human oversight — quality gates halt rather than ship unverified output
+- Guarantee zero hallucinations (human review remains essential)
+- Replace professional advisors or provide legal/financial/regulatory conclusions
+
+
+## Install Options
+
+=== "pip (recommended)"
+
+    ```bash
+    pip install dd-agents[pdf]
+    ```
+
+=== "pipx (isolated CLI)"
+
+    ```bash
+    pipx install dd-agents[pdf]
+    ```
+
+=== "Homebrew (macOS)"
+
+    ```bash
+    brew install zoharbabin/due-diligence-agents/dd-agents
+    ```
+
+=== "Docker"
+
+    ```bash
+    docker pull zoharbabin/due-diligence-agents:latest
+    docker run -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+      -v ./data_room:/data zoharbabin/due-diligence-agents run /data/deal-config.json
+    ```
+
+## Next Steps
+
+- [Getting Started](user-guide/getting-started.md) — full installation and first-run walkthrough
+- [Deal Configuration](user-guide/deal-configuration.md) — customize analysis focus areas
+- [CLI Reference](user-guide/cli-reference.md) — every command, flag, and exit code
+- [Contract Search Guide](search-guide.md) — targeted search without the full pipeline
+# DD-Agents — Forensic M&A Due Diligence
+
+**Legal flags a risk. Finance flags another. We connect and cite.** Open-source forensic M&A due diligence — 13 AI agents read your entire data room across 9 specialist domains, cross-reference the findings no single reviewer connects, and trace every one to an exact page and verbatim quote. Quality-gated HTML + Excel reports.
+
+## Quick Start
+
+```bash
+pip install dd-agents[pdf]
+export ANTHROPIC_API_KEY="sk-ant-..."
+dd-agents init --data-room ./your_data_room
+dd-agents run deal-config.json
+```
+
+**[See a sample report →](https://zoharbabin.github.io/due-diligence-agents/sample-report/)**
+
+## What It Does
+
+| Command | Purpose |
+|---------|---------|
+| `dd-agents run` | Full 38-step pipeline across 9 domains |
+| `dd-agents run --quick-scan` | Red flag triage in minutes |
+| `dd-agents search` | Targeted contract questions with citations |
+| `dd-agents chat` | Interactive multi-turn chat about findings |
+| `dd-agents query` | Single-question mode |
+| `dd-agents assess` | Data room quality check |
+
 ## Install Options
 
 === "pip (recommended)"

--- a/src/dd_agents/reporting/html_base.py
+++ b/src/dd_agents/reporting/html_base.py
@@ -743,6 +743,8 @@ table.sortable th { background: var(--bg-tertiary); cursor: pointer; user-select
 table.sortable th:hover { background: var(--border-light); }
 table.sortable th::after { content: ' \\2195'; color: #ccc; font-size: 0.8em; }
 table.sortable tr:hover td { background: var(--bg-tertiary); }
+table.sortable caption { caption-side: top; text-align: left; font-size: 0.78em;
+  color: var(--text-muted); padding: 0 0 6px; }
 
 /* Arrow toggle */
 .arrow { font-size: 0.8em; transition: transform 0.2s; display: inline-block; }

--- a/src/dd_agents/reporting/html_methodology.py
+++ b/src/dd_agents/reporting/html_methodology.py
@@ -46,7 +46,7 @@ class MethodologyRenderer(SectionRenderer):
         # Agent coverage
         parts.append("<h3>Agent Coverage</h3>")
         parts.append(
-            "<table class='sortable'><thead><tr>"
+            "<table class='sortable'><caption>Agent coverage by domain</caption><thead><tr>"
             "<th scope='col'>Domain</th><th scope='col'>Findings</th>"
             "<th scope='col'>Risk Level</th></tr></thead><tbody>"
         )

--- a/tests/unit/test_html_renderers.py
+++ b/tests/unit/test_html_renderers.py
@@ -1332,6 +1332,7 @@ class TestMethodologyRenderer:
         html_out = r.render()
         assert "<caption>Agent coverage by domain</caption>" in html_out
 
+
 # ===========================================================================
 # CSS Custom Properties (Issue #113 E1)
 # ===========================================================================

--- a/tests/unit/test_html_renderers.py
+++ b/tests/unit/test_html_renderers.py
@@ -1325,6 +1325,12 @@ class TestMethodologyRenderer:
         assert "Entities Analyzed" in html_out
         assert ">2</div>" in html_out  # 2 entities in test data
 
+    def test_methodology_agent_coverage_caption(self) -> None:
+        """Agent Coverage table should have an accessible caption."""
+        computed = _compute()
+        r = MethodologyRenderer(computed, _make_merged_data())
+        html_out = r.render()
+        assert "<caption>Agent coverage by domain</caption>" in html_out
 
 # ===========================================================================
 # CSS Custom Properties (Issue #113 E1)


### PR DESCRIPTION
Closes #208
Closes #210

Adds a "What dd-agents does (and does not) do" section to the docs landing page, and adds an accessible `<caption>` to the Agent Coverage report table (with matching CSS + test).

Maintainer follow-up commits: de-duplicated the docs page, polished the section to current positioning, and styled the table caption to the report design language. Validated — full unit suite passes, mypy --strict + ruff clean, docs-drift gate green.