### PR TITLE
fix(examples/agno-bindu): make the LLM provider configurable (provider-agnostic)

### DIFF
--- a/examples/agno-bindu/.env.example
+++ b/examples/agno-bindu/.env.example
@@ -1,9 +1,25 @@
-# Required: an OpenRouter key (https://openrouter.ai/keys). The agno model call
-# is the only thing that needs a key — reading the report findings does not.
-OPENROUTER_API_KEY=sk-or-...        # pragma: allowlist secret
+# --- LLM provider (provider-agnostic, like the dd-agents pipeline) ---
+# Pick the backend for the agno model call. The deterministic report tools need
+# NO key — only this conversational model call does. Each provider reads its own
+# standard credentials (the same ones you already use for the pipeline).
+#
+# Supported: bedrock | anthropic | openai | google | openrouter
+# Default is `bedrock` (Anthropic-on-Bedrock — your data stays in your AWS
+# account), matching dd-agents' enterprise posture.
+BINDU_AGENT_PROVIDER=bedrock
 
-# Optional overrides.
-BINDU_AGENT_MODEL=anthropic/claude-sonnet-4.5
+# Provide ONLY the credentials for the provider you chose above:
+#   bedrock    -> AWS credential chain (AWS_PROFILE / AWS_REGION, or keys)
+#   anthropic  -> ANTHROPIC_API_KEY=sk-ant-...      # pragma: allowlist secret
+#   openai     -> OPENAI_API_KEY=sk-...             # pragma: allowlist secret
+#   google     -> GOOGLE_API_KEY=...                # pragma: allowlist secret
+#   openrouter -> OPENROUTER_API_KEY=sk-or-...      # pragma: allowlist secret
+# AWS_PROFILE=default
+# AWS_REGION=us-east-1
+
+# Optional: override the model id for the chosen provider (otherwise a sensible
+# per-provider default is used). e.g. for openrouter: anthropic/claude-sonnet-4.5
+# BINDU_AGENT_MODEL=
 BINDU_AGENT_NAME=bindu-dd-analyst
 BINDU_AGENT_AUTHOR=bindu-examples@example.com
 BINDU_AGENT_URL=http://localhost:3773

--- a/examples/agno-bindu/README.md
+++ b/examples/agno-bindu/README.md
@@ -36,13 +36,19 @@ is the **light** part on the other side of that output. It:
    `dd_agents.query.indexer.FindingIndexer` — pure, deterministic Python, **no LLM**.
 2. Exposes three tools to an agno agent: `report_overview`, `list_findings`,
    `get_finding`.
-3. Lets the agno model (via OpenRouter) reason over those tools and answer
-   conversationally, leading with the answer and citing the source document,
-   section, and exact quote.
+3. Lets the agno model reason over those tools and answer conversationally,
+   leading with the answer and citing the source document, section, and exact
+   quote.
 
-Because the retrieval is deterministic and the only model call is agno's, **this
-example needs only an OpenRouter key — no Anthropic key**. (The dd-agents
-*pipeline* still needs Anthropic/Bedrock; reading its output here does not.)
+**Provider-agnostic, like the pipeline.** Pick the LLM backend with
+`BINDU_AGENT_PROVIDER` — `bedrock` (default), `anthropic`, `openai`, `google`,
+or `openrouter` — and supply only that provider's standard credentials (the same
+env you already use for the pipeline). The default is **Bedrock**, so by default
+your data stays inside your own AWS account; nothing is hardcoded to a single
+vendor. Because retrieval is deterministic and the only model call is agno's,
+**only that one conversational call needs a key** — reading the report findings
+does not. (The dd-agents *pipeline* that produced the report still needs its own
+Anthropic/Bedrock access; reading its output here does not.)
 
 By default the agent reads the bundled, 100%-synthetic **Project Atlas** golden
 report this repo ships at `docs/marketing/sample-report-atlas/` (real pipeline
@@ -69,9 +75,12 @@ All commands run from the **repo root**, with [uv](https://docs.astral.sh/uv/).
 ```bash
 uv venv                                                  # create a venv (Python 3.12+)
 uv pip install -e .                                      # the dd-agents engine (this repo)
-uv pip install -r examples/agno-bindu/requirements.txt   # agno + Bindu glue
+uv pip install -r examples/agno-bindu/requirements.txt   # agno + Bindu glue (Bedrock SDK by default)
 cp examples/agno-bindu/.env.example examples/agno-bindu/.env
-# edit examples/agno-bindu/.env and set OPENROUTER_API_KEY
+# edit examples/agno-bindu/.env: pick BINDU_AGENT_PROVIDER (default: bedrock) and
+# supply that provider's credentials. For a non-default provider, also install
+# its SDK (e.g. `uv pip install anthropic` / `openai` / `google-genai`) — see
+# the requirements.txt provider list.
 ```
 
 ## Run the CLI (one-shot)
@@ -197,7 +206,7 @@ Sources: forensic-dd_finance_northwind_logistics_0001, forensic-dd_commercial_no
   local dev origin (override with `BINDU_CORS_ORIGINS`).
 - **Exposing publicly is opt-in and unauthenticated by default.** Setting
   `BINDU_EXPOSE=true` asks Bindu to open a **public** tunnel, with your
-  OpenRouter key on the billing path. The example does not add an application
+  provider key on the billing path. The example does not add an application
   auth layer on the JSON-RPC `POST /` endpoint — it relies on Bindu's defaults.
   **Before exposing a real-deal report**, set `BINDU_AUTH_TOKEN` and confirm
   your Bindu version enforces it; the entry point logs a loud warning if you
@@ -220,7 +229,7 @@ Sources: forensic-dd_finance_northwind_logistics_0001, forensic-dd_commercial_no
 | `cli.py` | One-shot local runner |
 | `prompts.py` | Agent name, description, and system prompt |
 | `requirements.txt` | agno + Bindu glue deps (the engine comes from the parent repo) |
-| `.env.example` | `OPENROUTER_API_KEY`, `DD_REPORT_DIR`, exposure/auth/CORS knobs |
+| `.env.example` | `BINDU_AGENT_PROVIDER` + credentials, `DD_REPORT_DIR`, exposure/auth/CORS knobs |
 
 ## Tests
 

--- a/examples/agno-bindu/agent.py
+++ b/examples/agno-bindu/agent.py
@@ -6,38 +6,93 @@ runs; ``bindu_agent.py`` calls it to expose the agent over A2A.
 
 The agent's tools (in ``report_tools.py``) read a deal's *already-produced*
 merged findings through the upstream ``dd_agents.query`` finding index — pure,
-deterministic Python, no LLM and no Anthropic key. The agno model (via
-OpenRouter) supplies the conversational reasoning on top. The dd-agents pipeline
-itself is never run here.
+deterministic Python, no LLM and no key. The agno model supplies the
+conversational reasoning on top. The dd-agents pipeline itself is never run here.
+
+Provider-agnostic, like the pipeline: pick the LLM backend with
+``BINDU_AGENT_PROVIDER`` (default ``bedrock``, matching dd-agents' enterprise
+posture — your data stays within your own AWS account). Each provider reads its
+own standard credentials (the same env you already use for the pipeline), so no
+single vendor is hardcoded. See ``.env.example`` for the supported providers.
 """
 
 from __future__ import annotations
 
 import os
 from functools import lru_cache
+from typing import TYPE_CHECKING
 
-from agno.agent import Agent
-from agno.models.openrouter import OpenRouter
 from prompts import AGENT_DESCRIPTION, AGENT_NAME, SYSTEM_PROMPT
 
 # Deterministic, key-free report tools (also unit-tested without agno/bindu).
 from report_tools import TOOLS, report_path
 
-__all__ = ["build_agent", "get_agent", "report_path"]
+if TYPE_CHECKING:
+    from agno.agent import Agent
+    from agno.models.base import Model
+
+__all__ = ["BINDU_AGENT_PROVIDERS", "build_agent", "get_agent", "report_path"]
+
+# Default model id per provider (override with BINDU_AGENT_MODEL). These are
+# illustrative current Claude tiers; the example reasons over deterministic
+# tools, so any solid tool-calling model works.
+_DEFAULT_MODEL_ID: dict[str, str] = {
+    "bedrock": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "anthropic": "claude-sonnet-4-5-20250929",
+    "openai": "gpt-4o",
+    "google": "gemini-2.5-flash",
+    "openrouter": "anthropic/claude-sonnet-4.5",
+}
+
+# Human-readable list of supported providers (used in error messages + docs).
+BINDU_AGENT_PROVIDERS = tuple(_DEFAULT_MODEL_ID)
 
 
-def _build_model() -> OpenRouter:
-    api_key = os.getenv("OPENROUTER_API_KEY")
-    if not api_key:
-        raise RuntimeError("OPENROUTER_API_KEY is not set. Add it to your .env (see .env.example).")
-    return OpenRouter(
-        id=os.getenv("BINDU_AGENT_MODEL", "anthropic/claude-sonnet-4.5"),
-        api_key=api_key,
-        max_tokens=int(os.getenv("BINDU_AGENT_MAX_TOKENS", "4096")),
-    )
+def _build_model() -> Model:
+    """Build the agno model for the configured provider (BINDU_AGENT_PROVIDER).
+
+    Provider-agnostic by design — mirrors dd-agents' own "bring your own
+    provider" stance. The model class is imported lazily so installing only the
+    SDK for the provider you use is enough. Each provider reads its standard
+    credentials from the environment (e.g. AWS creds for Bedrock,
+    ``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``, ``GOOGLE_API_KEY``,
+    ``OPENROUTER_API_KEY``), exactly as the agno docs specify.
+    """
+    provider = os.getenv("BINDU_AGENT_PROVIDER", "bedrock").strip().lower()
+    if provider not in _DEFAULT_MODEL_ID:
+        raise RuntimeError(
+            f"Unknown BINDU_AGENT_PROVIDER {provider!r}. Choose one of: {', '.join(BINDU_AGENT_PROVIDERS)}."
+        )
+    model_id = os.getenv("BINDU_AGENT_MODEL", _DEFAULT_MODEL_ID[provider])
+    max_tokens = int(os.getenv("BINDU_AGENT_MAX_TOKENS", "4096"))
+
+    if provider == "bedrock":
+        # Anthropic-on-Bedrock — your data stays in your AWS account. Reads the
+        # standard AWS credential chain (AWS_PROFILE / AWS_REGION / keys).
+        from agno.models.aws import Claude as BedrockClaude
+
+        return BedrockClaude(id=model_id, max_tokens=max_tokens)
+    if provider == "anthropic":
+        from agno.models.anthropic import Claude
+
+        return Claude(id=model_id, max_tokens=max_tokens)
+    if provider == "openai":
+        from agno.models.openai import OpenAIChat
+
+        return OpenAIChat(id=model_id, max_tokens=max_tokens)
+    if provider == "google":
+        from agno.models.google import Gemini
+
+        return Gemini(id=model_id)
+    # openrouter
+    from agno.models.openrouter import OpenRouter
+
+    return OpenRouter(id=model_id, max_tokens=max_tokens)
 
 
 def build_agent() -> Agent:
+    from agno.agent import Agent
+
     return Agent(
         name=AGENT_NAME,
         description=AGENT_DESCRIPTION,
@@ -52,9 +107,10 @@ def build_agent() -> Agent:
 def get_agent() -> Agent:
     """Build the agno agent once, on first use.
 
-    Lazy by design: constructing the model needs ``OPENROUTER_API_KEY``, but the
-    three deterministic tools and the finding index do NOT. Deferring the build
-    keeps this module importable — and the tools unit-testable in CI — without
-    any API key.
+    Lazy by design: constructing the model needs provider credentials
+    (``BINDU_AGENT_PROVIDER``), but the three deterministic tools and the finding
+    index do NOT. Deferring the build keeps this module importable — and the
+    tools unit-testable in CI — without any key. The agno import is also lazy so
+    the report tools can be exercised without agno installed.
     """
     return build_agent()

--- a/examples/agno-bindu/requirements.txt
+++ b/examples/agno-bindu/requirements.txt
@@ -6,9 +6,9 @@
 # Then install these:
 #     uv pip install -r examples/agno-bindu/requirements.txt
 #
-# Note: this example only reads the dd-agents *finding index* (deterministic,
-# no LLM), so it does not need an Anthropic key — only OPENROUTER_API_KEY for the
-# agno model call.
+# Note: the dd-agents *finding index* the tools read is deterministic and needs
+# no key. Only the conversational agno model call needs provider credentials —
+# and the provider is YOUR choice (BINDU_AGENT_PROVIDER; see .env.example).
 #
 # Pins: capped to the versions this example was validated against. Bindu owns
 # the A2A service's auth/exposure/CORS defaults, so its version is held to a
@@ -19,3 +19,12 @@ bindu>=2026.21.2,<2027
 agno>=2.6.5,<2.7
 python-dotenv>=1.0,<2
 rich>=13,<15
+
+# Provider SDK — install ONLY the one matching BINDU_AGENT_PROVIDER (agno
+# lazy-imports the vendor client, so you don't need all of them):
+#   bedrock (default) -> anthropic     (Anthropic-on-Bedrock; uses AWS creds)
+#   anthropic         -> anthropic
+#   openai            -> openai
+#   google            -> google-genai
+#   openrouter        -> openai         (OpenRouter speaks the OpenAI API)
+anthropic>=0.40       # default provider (Bedrock via Anthropic SDK); swap per the list above


### PR DESCRIPTION
Follow-up to #220. The agno-bindu example hardcoded agno's OpenRouter model and required `OPENROUTER_API_KEY` as the **only** path to run it — which contradicts dd-agents' provider-agnostic, bring-your-own-backend stance (the pipeline runs on the Anthropic API *or* AWS Bedrock purely by env config, nothing hardcoded). An enterprise user analyzing deals inside their own Bedrock VPC shouldn't have to sign up for OpenRouter and route data + billing through a third party just to try the example.

## What changed

- **`agent.py` `_build_model()` is now a provider factory** keyed on `BINDU_AGENT_PROVIDER`:
  `bedrock` (default) · `anthropic` · `openai` · `google` · `openrouter`.
  Each provider's agno model class is imported **lazily** (agno lazy-loads the vendor SDK, so you install only the one you use) and reads that provider's **standard credentials** — the same env you already use for the pipeline. Unknown providers fail with a clear message listing the valid set.
- **Default is `bedrock`** (Anthropic-on-Bedrock) so, by default, your data stays inside your own AWS account — matching dd-agents' enterprise posture.
- `BINDU_AGENT_MODEL` overrides the per-provider default model id.
- **`.env.example`**: documents the provider switch and which credential each provider needs.
- **`requirements.txt`**: install only the SDK for the chosen provider (`bedrock` → `anthropic`, since agno's Bedrock-Claude class uses the Anthropic SDK's Bedrock transport).
- **README**: provider-agnostic wording; default-Bedrock note.

## Validation

- Live: `BINDU_AGENT_PROVIDER=bedrock` builds `agno.models.aws.Claude` with the right model id, and `get_agent()` assembles the 3-tool Agent; an unknown provider errors cleanly. (Verified against `agno 2.6.5` + `anthropic` SDK.)
- The keyless tool test (`tests/unit/test_agno_bindu_example.py`) stays green — the deterministic tools are unchanged and still need no key.
- `ruff` + `ruff format` clean; docs-drift green.

Still fully opt-in and isolated to `examples/agno-bindu/` — nothing enters the published wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)