### PR TITLE
fix: honest model/provider-agnosticism — example default + docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,16 +2,31 @@
 # Due Diligence Agent SDK — Environment Variables
 # ==============================================================================
 # Copy this file to .env and uncomment/set the variables you need.
-# Only ONE API access method is required (Option A or B).
+# Only ONE API access method is required (Option A, B, or C).
+#
+# dd-agents runs on the Claude Agent SDK, so the model family is Claude — but
+# the PROVIDER/transport is your choice and is selected entirely by the env
+# vars below (the SDK forwards them to the bundled Claude CLI; dd-agents adds no
+# provider code). Pick the option matching your account.
 
-# --- API Access (required — choose one) ---
+# --- LLM provider access (required — choose one) ---
 
 # Option A: Anthropic API (recommended for new developers)
 # ANTHROPIC_API_KEY=sk-ant-...
 
-# Option B: AWS Bedrock
+# Option B: AWS Bedrock — set the routing flag AND your AWS credentials.
+# CLAUDE_CODE_USE_BEDROCK=1
 # AWS_PROFILE=default
 # AWS_REGION=us-east-1
+
+# Option C: Google Vertex AI — set the routing flag AND your GCP project/region.
+# CLAUDE_CODE_USE_VERTEX=1
+# ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project
+# CLOUD_ML_REGION=us-east5
+
+# Advanced: route through an Anthropic-Messages-compatible gateway/proxy.
+# ANTHROPIC_BASE_URL=https://your-gateway.example.com
+# ANTHROPIC_AUTH_TOKEN=...        # pragma: allowlist secret
 
 # --- Optional ---
 

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ The pipeline **halts on quality failures** rather than producing unreliable outp
 
 ## Security & Privacy
 
-- **Local execution** — all analysis runs on your machine. Documents only leave your machine as API calls to your configured LLM provider (Anthropic or AWS Bedrock).
+- **Local execution** — all analysis runs on your machine. Documents only leave your machine as API calls to your configured LLM provider (Anthropic API, AWS Bedrock, or Google Vertex AI).
 - **No telemetry** — the tool does not phone home, collect usage data, or send analytics anywhere.
 - **Read-only** — the tool never modifies files in your data room. Output is written to a separate `_dd/` directory.
 - **No persistent credentials** — API keys are read from environment variables or `.env` files, never stored in output artifacts.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ We will acknowledge receipt within 48 hours and aim to provide a fix or mitigati
 
 This tool processes potentially sensitive M&A documents. Key security measures:
 
-- **Local execution** — all analysis runs on your machine. No data is sent to third parties except the configured LLM API (Anthropic or AWS Bedrock).
+- **Local execution** — all analysis runs on your machine. No data is sent to third parties except the configured LLM API (Anthropic API, AWS Bedrock, or Google Vertex AI).
 - **No telemetry** — the tool does not phone home or collect usage data.
 - **Bash guard** — shell command execution is restricted to prevent injection.
 - **SSRF prevention** — external URL fetching is limited to document-referenced URLs with legal keyword patterns.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ dd-agents is a **forensic analysis accelerator** for M&A due diligence — it ge
 - Read an entire data room across 9 domains and **cross-reference** findings no single-domain reviewer connects.
 - Trace every finding to an exact page and verbatim quote, so each conclusion is auditable.
 - Halt rather than ship unverified output — quality gates are fail-closed, not advisory.
-- Run locally: documents only leave your machine as API calls to your own LLM provider (Anthropic or AWS Bedrock).
+- Run locally: documents only leave your machine as API calls to your own LLM provider (Anthropic API, AWS Bedrock, or Google Vertex AI — your choice, via env config).
 - Produce structured output (interactive HTML, Excel, JSON) you use as a **basis** for IC memos, advisor reports, and negotiation checklists.
 
 **It does not:**

--- a/docs/user-guide/deal-configuration.md
+++ b/docs/user-guide/deal-configuration.md
@@ -322,10 +322,16 @@ Text extraction (non-scanned PDFs) uses a separate chain: pymupdf → pdftotext 
 
 ### agent_models
 
-Controls which Claude models are used:
+Controls which Claude models are used. dd-agents runs on the Claude Agent SDK,
+so model IDs must be **Claude models**, in the form your configured provider
+expects — Anthropic short IDs (`claude-opus-4-8`) on the Anthropic API, or the
+prefixed IDs your provider uses on Bedrock/Vertex (e.g.
+`us.anthropic.claude-...`). Non-Claude vendors (GPT, Gemini) are not supported
+by the core pipeline; the provider/transport is selected by environment
+variables (see `.env.example`), not here.
 
 - `profile`: preset model tier — see table below
-- `overrides`: per-agent model IDs, e.g. `{"legal": "claude-opus-4-8"}`
+- `overrides`: per-agent Claude model IDs, e.g. `{"legal": "claude-opus-4-8"}`
 - `budget_limit_usd`: optional hard spending cap per run
 
 Model assignments per profile:

--- a/examples/agno-bindu/.env.example
+++ b/examples/agno-bindu/.env.example
@@ -3,17 +3,19 @@
 # NO key — only this conversational model call does. Each provider reads its own
 # standard credentials (the same ones you already use for the pipeline).
 #
-# Supported: bedrock | anthropic | openai | google | openrouter
-# Default is `bedrock` (Anthropic-on-Bedrock — your data stays in your AWS
-# account), matching dd-agents' enterprise posture.
-BINDU_AGENT_PROVIDER=bedrock
+# Supported: anthropic | bedrock | openai | google | openrouter
+# Default is `anthropic` (lowest friction: one key, no AWS account). Switch to
+# `bedrock` to keep data inside your AWS account, or any other provider you use.
+BINDU_AGENT_PROVIDER=anthropic
 
-# Provide ONLY the credentials for the provider you chose above:
-#   bedrock    -> AWS credential chain (AWS_PROFILE / AWS_REGION, or keys)
+# Provide ONLY the credentials for the provider you chose above, and install its
+# SDK (see requirements.txt — e.g. `anthropic[bedrock]` for bedrock):
 #   anthropic  -> ANTHROPIC_API_KEY=sk-ant-...      # pragma: allowlist secret
+#   bedrock    -> AWS credential chain (AWS_PROFILE / AWS_REGION, or keys)
 #   openai     -> OPENAI_API_KEY=sk-...             # pragma: allowlist secret
 #   google     -> GOOGLE_API_KEY=...                # pragma: allowlist secret
 #   openrouter -> OPENROUTER_API_KEY=sk-or-...      # pragma: allowlist secret
+ANTHROPIC_API_KEY=sk-ant-...        # pragma: allowlist secret
 # AWS_PROFILE=default
 # AWS_REGION=us-east-1
 

--- a/examples/agno-bindu/README.md
+++ b/examples/agno-bindu/README.md
@@ -41,12 +41,13 @@ is the **light** part on the other side of that output. It:
    quote.
 
 **Provider-agnostic, like the pipeline.** Pick the LLM backend with
-`BINDU_AGENT_PROVIDER` — `bedrock` (default), `anthropic`, `openai`, `google`,
+`BINDU_AGENT_PROVIDER` — `anthropic` (default), `bedrock`, `openai`, `google`,
 or `openrouter` — and supply only that provider's standard credentials (the same
-env you already use for the pipeline). The default is **Bedrock**, so by default
-your data stays inside your own AWS account; nothing is hardcoded to a single
-vendor. Because retrieval is deterministic and the only model call is agno's,
-**only that one conversational call needs a key** — reading the report findings
+env you already use for the pipeline). The default is **anthropic** (one
+`ANTHROPIC_API_KEY`, no AWS account or extra SDK — the lowest-friction way to
+try it); switch to `bedrock` to keep data inside your own AWS account. Nothing
+is hardcoded to a single vendor. Because retrieval is deterministic and the only
+model call is agno's, **only that one conversational call needs a key** — reading the report findings
 does not. (The dd-agents *pipeline* that produced the report still needs its own
 Anthropic/Bedrock access; reading its output here does not.)
 
@@ -75,11 +76,11 @@ All commands run from the **repo root**, with [uv](https://docs.astral.sh/uv/).
 ```bash
 uv venv                                                  # create a venv (Python 3.12+)
 uv pip install -e .                                      # the dd-agents engine (this repo)
-uv pip install -r examples/agno-bindu/requirements.txt   # agno + Bindu glue (Bedrock SDK by default)
+uv pip install -r examples/agno-bindu/requirements.txt   # agno + Bindu glue (Anthropic SDK by default)
 cp examples/agno-bindu/.env.example examples/agno-bindu/.env
-# edit examples/agno-bindu/.env: pick BINDU_AGENT_PROVIDER (default: bedrock) and
+# edit examples/agno-bindu/.env: pick BINDU_AGENT_PROVIDER (default: anthropic) and
 # supply that provider's credentials. For a non-default provider, also install
-# its SDK (e.g. `uv pip install anthropic` / `openai` / `google-genai`) — see
+# its SDK (e.g. `anthropic[bedrock]` for bedrock, `openai`, `google-genai`) — see
 # the requirements.txt provider list.
 ```
 

--- a/examples/agno-bindu/agent.py
+++ b/examples/agno-bindu/agent.py
@@ -10,10 +10,11 @@ deterministic Python, no LLM and no key. The agno model supplies the
 conversational reasoning on top. The dd-agents pipeline itself is never run here.
 
 Provider-agnostic, like the pipeline: pick the LLM backend with
-``BINDU_AGENT_PROVIDER`` (default ``bedrock``, matching dd-agents' enterprise
-posture — your data stays within your own AWS account). Each provider reads its
-own standard credentials (the same env you already use for the pipeline), so no
-single vendor is hardcoded. See ``.env.example`` for the supported providers.
+``BINDU_AGENT_PROVIDER`` (default ``anthropic`` — lowest friction; switch to
+``bedrock`` to keep data inside your own AWS account, or ``openai`` / ``google``
+/ ``openrouter``). Each provider reads its own standard credentials (the same
+env you already use for the pipeline), so no single vendor is hardcoded. See
+``.env.example`` for the supported providers.
 """
 
 from __future__ import annotations
@@ -33,9 +34,9 @@ if TYPE_CHECKING:
 
 __all__ = ["BINDU_AGENT_PROVIDERS", "build_agent", "get_agent", "report_path"]
 
-# Default model id per provider (override with BINDU_AGENT_MODEL). These are
-# illustrative current Claude tiers; the example reasons over deterministic
-# tools, so any solid tool-calling model works.
+# Default model id per provider (override with BINDU_AGENT_MODEL). Illustrative
+# tool-calling models; the example reasons over deterministic tools, so any
+# solid tool-calling model works. Update as providers release newer models.
 _DEFAULT_MODEL_ID: dict[str, str] = {
     "bedrock": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
     "anthropic": "claude-sonnet-4-5-20250929",
@@ -58,7 +59,11 @@ def _build_model() -> Model:
     ``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``, ``GOOGLE_API_KEY``,
     ``OPENROUTER_API_KEY``), exactly as the agno docs specify.
     """
-    provider = os.getenv("BINDU_AGENT_PROVIDER", "bedrock").strip().lower()
+    # Default to `anthropic`: lowest-friction for a copy-paste example — one
+    # ANTHROPIC_API_KEY, no AWS account or extra SDK. Switch to bedrock/vertex/
+    # openai/google/openrouter to match your stack (mirrors dd-agents' own
+    # provider-flexible posture).
+    provider = os.getenv("BINDU_AGENT_PROVIDER", "anthropic").strip().lower()
     if provider not in _DEFAULT_MODEL_ID:
         raise RuntimeError(
             f"Unknown BINDU_AGENT_PROVIDER {provider!r}. Choose one of: {', '.join(BINDU_AGENT_PROVIDERS)}."
@@ -66,16 +71,17 @@ def _build_model() -> Model:
     model_id = os.getenv("BINDU_AGENT_MODEL", _DEFAULT_MODEL_ID[provider])
     max_tokens = int(os.getenv("BINDU_AGENT_MAX_TOKENS", "4096"))
 
-    if provider == "bedrock":
-        # Anthropic-on-Bedrock — your data stays in your AWS account. Reads the
-        # standard AWS credential chain (AWS_PROFILE / AWS_REGION / keys).
-        from agno.models.aws import Claude as BedrockClaude
-
-        return BedrockClaude(id=model_id, max_tokens=max_tokens)
     if provider == "anthropic":
         from agno.models.anthropic import Claude
 
         return Claude(id=model_id, max_tokens=max_tokens)
+    if provider == "bedrock":
+        # Anthropic-on-Bedrock — your data stays in your AWS account. Needs the
+        # `anthropic[bedrock]` extra (boto3) + the standard AWS credential chain
+        # (AWS_PROFILE / AWS_REGION / keys); see requirements.txt.
+        from agno.models.aws import Claude as BedrockClaude
+
+        return BedrockClaude(id=model_id, max_tokens=max_tokens)
     if provider == "openai":
         from agno.models.openai import OpenAIChat
 
@@ -83,7 +89,8 @@ def _build_model() -> Model:
     if provider == "google":
         from agno.models.google import Gemini
 
-        return Gemini(id=model_id)
+        # agno's Gemini uses `max_output_tokens` (not `max_tokens`).
+        return Gemini(id=model_id, max_output_tokens=max_tokens)
     # openrouter
     from agno.models.openrouter import OpenRouter
 

--- a/examples/agno-bindu/bindu_agent.py
+++ b/examples/agno-bindu/bindu_agent.py
@@ -1,8 +1,9 @@
 """Atlas DD Analyst exposed as a Bindu A2A agent (synchronous — no MCP, no loop).
 
 The handler reads a completed dd-agents report through the upstream finding index
-and lets the agno agent answer over it. Tools are deterministic and need no
-Anthropic key; only the agno model call (via OpenRouter) needs OPENROUTER_API_KEY.
+and lets the agno agent answer over it. The tools are deterministic and need no
+key; only the agno model call needs your chosen provider's credentials
+(BINDU_AGENT_PROVIDER; see .env.example).
 
 Run:  uv run python examples/agno-bindu/bindu_agent.py
 """
@@ -18,9 +19,9 @@ from bindu.penguin.bindufy import bindufy
 from dotenv import load_dotenv
 from prompts import AGENT_DESCRIPTION
 
-# Load the example's .env so OPENROUTER_API_KEY is present before the model is
-# built. The agent is built lazily inside get_agent(), so importing `agent`
-# above is key-free; the key is only needed when the first request arrives.
+# Load the example's .env so the provider credentials are present before the
+# model is built. The agent is built lazily inside get_agent(), so importing
+# `agent` above is key-free; the key is only needed on the first request.
 load_dotenv(Path(__file__).with_name(".env"))
 
 logger = logging.getLogger(__name__)
@@ -47,14 +48,14 @@ def handler(messages):
 
 # Optional bearer token for the A2A endpoint. Strongly recommended before
 # exposing publicly (BINDU_EXPOSE=true) — without it, every accepted request
-# spends your OpenRouter key and returns full report contents.
+# spends your provider key and returns full report contents.
 _AUTH_TOKEN = os.getenv("BINDU_AUTH_TOKEN", "").strip()
 _EXPOSE = os.getenv("BINDU_EXPOSE", "false").lower() == "true"
 if _EXPOSE and not _AUTH_TOKEN:
     logger.warning(
         "BINDU_EXPOSE=true but BINDU_AUTH_TOKEN is unset: the agent will be "
         "publicly reachable with NO application-layer auth — every call bills "
-        "your OpenRouter key and returns report contents. Set BINDU_AUTH_TOKEN "
+        "your provider key and returns report contents. Set BINDU_AUTH_TOKEN "
         "or keep BINDU_EXPOSE=false for local use."
     )
 

--- a/examples/agno-bindu/requirements.txt
+++ b/examples/agno-bindu/requirements.txt
@@ -22,9 +22,9 @@ rich>=13,<15
 
 # Provider SDK — install ONLY the one matching BINDU_AGENT_PROVIDER (agno
 # lazy-imports the vendor client, so you don't need all of them):
-#   bedrock (default) -> anthropic     (Anthropic-on-Bedrock; uses AWS creds)
-#   anthropic         -> anthropic
-#   openai            -> openai
-#   google            -> google-genai
-#   openrouter        -> openai         (OpenRouter speaks the OpenAI API)
-anthropic>=0.40       # default provider (Bedrock via Anthropic SDK); swap per the list above
+#   anthropic (default) -> anthropic
+#   bedrock             -> anthropic[bedrock]   (pulls boto3; Anthropic-on-Bedrock)
+#   openai              -> openai
+#   google              -> google-genai
+#   openrouter          -> openai               (OpenRouter speaks the OpenAI API)
+anthropic>=0.40       # default provider; for bedrock use:  anthropic[bedrock]>=0.40


### PR DESCRIPTION
Follow-up to the agno-bindu review. You flagged the `OPENROUTER_API_KEY` requirement as odd given the project's provider-agnostic stance — you were right, and a deep audit (every LLM path, 42-agent workflow, each finding verified against code + the installed SDK) clarified exactly where we are and aren't agnostic.

## The verdict (the distinction that matters)

- **Core pipeline — PROVIDER-agnostic: YES** (real and complete). Anthropic API / AWS Bedrock / Google Vertex / any Anthropic-Messages-compatible proxy are all reachable **env-only**, with zero provider/auth code in `src/dd_agents/` — the Claude Agent SDK forwards the environment to the bundled `claude` CLI, which natively honors `CLAUDE_CODE_USE_BEDROCK` / `CLAUDE_CODE_USE_VERTEX` / `ANTHROPIC_BASE_URL`.
- **Core pipeline — MODEL-agnostic across vendors (GPT/Gemini): NO** — and not by accident. The whole core rides `claude-agent-sdk` (the *only* LLM dependency), whose bundled CLI model catalog is Claude-only. That SDK is also where the code-enforced safety floor, MCP tool-use, hooks, and citation guarantees live — the things forensic DD trades on. So this is a deliberate ceiling, not a bug.
- **The agno-bindu example — model- AND provider-agnostic: yes by design** (separate stack), but its shipped Bedrock default was **broken**.

## What this PR fixes

**Example (one real bug + polish):**
- The `bedrock` default couldn't run from `requirements.txt` — agno's AWS Claude needs `anthropic[bedrock]` (boto3), but requirements listed only `anthropic`. **Changed the default to `anthropic`** (one key, no AWS account, no extra SDK — the right default for a copy-paste example) and corrected the per-provider SDK notes.
- Gemini branch now passes `max_output_tokens` (agno's actual param), not the silently-dropped `max_tokens`.
- Removed stale "via OpenRouter / OpenRouter key" wording left after the provider factory landed.

**Core docs (make the real posture honest — no code change, no over-claim):**
- `.env.example`: document the actual routing flags the SDK reads — `CLAUDE_CODE_USE_BEDROCK` (Option B was missing it), `CLAUDE_CODE_USE_VERTEX` (Option C, previously undocumented), and the `ANTHROPIC_BASE_URL` gateway path.
- `index.md` / `README` / `SECURITY`: "Anthropic or AWS Bedrock" → "Anthropic API, AWS Bedrock, or Google Vertex AI" (Vertex is zero-code supported and was invisible).
- `deal-configuration.md`: `agent_models.overrides` take **Claude** model IDs in the form the configured provider expects; non-Claude vendors aren't supported by the core.

## Note on my earlier "validated live" claim
I'd said the Bedrock example path was validated — it built the model object, but only because my scratch venv happened to also have `boto3`; the shipped requirements would have failed on first call. That's the defect fixed here. Mea culpa on the overstatement.

Validated: default `anthropic` provider builds the agno model; keyless example test green; 4232 unit + docs-drift pass; ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)