### PR TITLE
feat(llm): whole-system model/provider-agnosticism — fix silent CLI no-op, add audit receipt + doctor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,18 @@
 # DD_AUTOCONFIG_MODEL=
 # DD_VISION_MODEL=
 
+# --- Local extraction model paths (optional; no remote provider) ---
+# These select LOCAL models for OCR and audio transcription, independent of the
+# reasoning LLM provider above.
+
+# Audio/video transcription backend + model (local Whisper variants).
+# DD_TRANSCRIPTION_BACKEND=mlx        # mlx | whisperx | openai
+# DD_TRANSCRIPTION_MODEL=
+
+# GLM-OCR local model tags (override to point OCR at a different local build).
+# DD_OCR_MODEL_MLX=mlx-community/GLM-OCR-8bit
+# DD_OCR_MODEL_OLLAMA=glm-ocr
+
 # --- Optional ---
 
 # ChromaDB: persist vector search index to disk (default: memory-only)

--- a/README.md
+++ b/README.md
@@ -214,9 +214,16 @@ cp .env.example .env
 
 **AWS Bedrock** (if you use AWS):
 ```bash
+export CLAUDE_CODE_USE_BEDROCK=1
 export AWS_PROFILE=default
 export AWS_REGION=us-east-1
 ```
+
+**Any model — no vendor lock-in.** dd-agents is provider- *and* model-agnostic by
+env config (no code change): Anthropic API, your own **AWS Bedrock** or **Google
+Vertex AI** account, or **any model** (GPT, Gemini, DeepSeek, local) behind an
+Anthropic-compatible gateway. Verify your setup with `dd-agents doctor`. See
+[Model Providers](docs/user-guide/model-providers.md).
 </details>
 
 <details>
@@ -326,7 +333,7 @@ The pipeline **halts on quality failures** rather than producing unreliable outp
 
 ## Security & Privacy
 
-- **Local execution** — all analysis runs on your machine. Documents only leave your machine as API calls to your configured LLM provider (Anthropic API, AWS Bedrock, or Google Vertex AI).
+- **Local execution** — all analysis runs on your machine. Documents only leave your machine as API calls to your configured LLM endpoint — Anthropic API, AWS Bedrock, Google Vertex AI, or an Anthropic-compatible gateway you point it at. See [Model Providers](docs/user-guide/model-providers.md).
 - **No telemetry** — the tool does not phone home, collect usage data, or send analytics anywhere.
 - **Read-only** — the tool never modifies files in your data room. Output is written to a separate `_dd/` directory.
 - **No persistent credentials** — API keys are read from environment variables or `.env` files, never stored in output artifacts.

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -96,6 +96,22 @@ dd-agents version --json    # machine-readable: {"version": "..."}
 
 ---
 
+## doctor
+
+Verify the configured LLM provider/model routing before a run. Prints the
+active provider/gateway (secret-free — embedded credentials are stripped),
+checks that a credential is present, and exits non-zero on misconfiguration.
+
+```
+dd-agents doctor            # show routing + credential check
+dd-agents doctor --probe    # also issue one minimal live query
+dd-agents doctor --json     # machine-readable routing receipt
+```
+
+See [Model Providers](model-providers.md) for the full provider/model story.
+
+---
+
 ## init
 
 Generate a deal-config.json by scanning a data room. Supports interactive and

--- a/docs/user-guide/model-providers.md
+++ b/docs/user-guide/model-providers.md
@@ -22,6 +22,19 @@ export ANTHROPIC_AUTH_TOKEN=sk-anything            # pragma: allowlist secret
 export DD_MAX_OUTPUT_TOKENS=4096                    # clamp if the backing model caps lower
 ```
 
+## Verify before you run
+
+```bash
+dd-agents doctor            # show the active provider/model routing + credential check
+dd-agents doctor --probe    # also issue one minimal live query to confirm the endpoint answers
+dd-agents doctor --json     # machine-readable routing receipt (exit 1 if misconfigured)
+```
+
+`doctor` is the fast pre-flight: it prints which provider/gateway will answer
+(secret-free — credentials in `ANTHROPIC_BASE_URL` are stripped), confirms a
+credential is present, and with `--probe` round-trips a real query. Use it to
+validate a Bedrock / Vertex / gateway setup before committing to a full run.
+
 ## How it works (the contract)
 
 Every reasoning-LLM call in dd-agents is built by one seam —
@@ -38,11 +51,28 @@ gateway lets you reach models from any vendor without changing dd-agents.
 - **Other models** (GPT, Gemini, DeepSeek, local, …): run an Anthropic-compatible gateway and point `ANTHROPIC_BASE_URL` at it. The model family is whatever the gateway serves.
 - **If a query 400s on token limits** behind a gateway, set `DD_MAX_OUTPUT_TOKENS` (the seam exports it as `CLAUDE_CODE_MAX_OUTPUT_TOKENS`) to a value within the backing model's output cap.
 - **Cost accuracy for non-Claude models**: set `DD_MODEL_PRICING` (JSON: `{"<model-id>": {"input": <usd_per_mtok>, "output": <…>}}`). Unknown models are estimated at default rates and logged as such, never silently presented as exact.
-- **Pin a model per call path** (optional): `agent_models.overrides` in the deal config (specialists/synthesis), and `DD_QUERY_MODEL` / `DD_SEARCH_MODEL` / `DD_AUTOCONFIG_MODEL` / `DD_VISION_MODEL` for the auxiliary reasoning paths. Use the id form your endpoint expects.
+- **Pin a model per call path** (optional): `agent_models.overrides` in the deal config (specialists/synthesis), and `DD_QUERY_MODEL` / `DD_SEARCH_MODEL` / `DD_AUTOCONFIG_MODEL` / `DD_VISION_MODEL` for the auxiliary reasoning paths. Use the id form your endpoint expects. CLI `--model-profile` / `--model-override` apply to a `run` and are folded into the run's provenance hash.
+
+## Auxiliary (local) model paths
+
+Beyond the reasoning LLM, two extraction paths use **local** models — independent of your provider choice, no remote calls:
+
+- **OCR** (scanned PDFs): selected by `extraction.ocr_backend` in the deal config (`auto` | `glm_ocr` | `pytesseract`); the local GLM-OCR model tag is overridable via `DD_OCR_MODEL_MLX` / `DD_OCR_MODEL_OLLAMA`.
+- **Transcription** (audio/video): `DD_TRANSCRIPTION_BACKEND` (`mlx` | `whisperx` | `openai`-local-whisper) and `DD_TRANSCRIPTION_MODEL`.
+
+Entity resolution and the knowledge base use no remote model (local TF-IDF / no embedding RAG).
+
+## Resume is provider-locked
+
+The fail-closed resume gate folds the active provider/gateway routing into the run's provenance hash. A checkpoint is only resumable under the **same** provider/model routing it was created with; switching transport (e.g. Anthropic API → a gateway, or flipping Bedrock) between the original run and a `--resume-from` is rejected rather than silently stitching findings from two backends into one report. Start a fresh run to change providers.
+
+## Auditability
+
+Every run records a secret-free **routing receipt** — the active provider, the gateway base URL (host only, credentials stripped), and the distinct model ids actually used. It is persisted to the run's `metadata.json` (`llm_provider` / `llm_base_url` / `llm_models`) and `cost_summary.json` (`routing`), and surfaced in the HTML report's *Generation Provenance* section and the Excel `_Metadata` sheet. So an auditor can later prove which provider/model produced the findings.
 
 ## Use any model via a LiteLLM gateway (recipe)
 
-A copy-paste recipe lives in [`examples/litellm-gateway/`](https://github.com/zoharbabin/due-diligence-agents/tree/main/examples/litellm-gateway) — a LiteLLM config mapping a model name to your chosen backend, plus the exact env to point dd-agents at it. The repo's gateway end-to-end test (`tests/e2e/test_gateway_provider.py`, `-m gateway`) is the automated proof that a real query completes through it.
+A copy-paste recipe lives in [`examples/litellm-gateway/`](https://github.com/zoharbabin/due-diligence-agents/tree/main/examples/litellm-gateway) — a LiteLLM config mapping a model name to your chosen backend, plus the exact env to point dd-agents at it. The repo ships an **opt-in** gateway end-to-end test (`tests/e2e/test_gateway_provider.py`, `-m gateway`) that runs a real query through a gateway you stand up; it is skipped in the standard CI matrix (no proxy) and is run manually to validate your own gateway.
 
 ## Caveats
 

--- a/examples/litellm-gateway/README.md
+++ b/examples/litellm-gateway/README.md
@@ -31,7 +31,15 @@ chosen backend (OpenAI / Gemini / a non-Claude Bedrock model / local).
 
 ## Verify it works
 
-The repo ships an automated end-to-end check:
+First, a quick pre-flight that prints the active routing and round-trips one query:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:4011 ANTHROPIC_AUTH_TOKEN=sk-anything \
+  dd-agents doctor --probe          # pragma: allowlist secret
+```
+
+The repo also ships an opt-in end-to-end check (skipped in the standard CI
+matrix, which has no proxy — run it manually against your gateway):
 
 ```bash
 DD_TEST_GATEWAY_URL=http://localhost:4011 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ pdf = ["pymupdf>=1.23"]
 vector = ["chromadb>=0.4"]
 ocr = ["pytesseract>=0.3", "Pillow>=12.1", "pdf2image>=1.16"]
 glm-ocr = ["mlx-vlm>=0.1", "pypdfium2>=4.0", "Pillow>=12.1"]
+# Cross-platform GLM-OCR via Ollama (needs a running ollama daemon + a pulled
+# glm-ocr model). The mlx-vlm path above is Apple-Silicon only.
+glm-ocr-ollama = ["ollama>=0.3", "pypdfium2>=4.0", "Pillow>=12.1"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/src/dd_agents/agents/cost_tracker.py
+++ b/src/dd_agents/agents/cost_tracker.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 from collections import defaultdict
 from typing import Any
 
@@ -42,6 +43,7 @@ _DEFAULT_PRICING: dict[str, float] = {"input": 3.0, "output": 15.0}
 
 # Models we've already warned about (one warning per unknown model per process).
 _WARNED_UNKNOWN_MODELS: set[str] = set()
+_WARNED_LOCK = threading.Lock()
 
 
 def _load_pricing_overrides() -> dict[str, dict[str, float]]:
@@ -83,13 +85,17 @@ def _estimate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
         pricing = _load_pricing_overrides().get(model)
     if pricing is None:
         pricing = _DEFAULT_PRICING
-        if model not in _WARNED_UNKNOWN_MODELS:
-            _WARNED_UNKNOWN_MODELS.add(model)
-            logger.warning(
-                "No pricing for model %r — estimating at default (Sonnet-shaped) rates. "
-                "Set DD_MODEL_PRICING to cost it accurately.",
-                model,
-            )
+        # Advisory one-warning-per-unknown-model dedup. Guarded so concurrent
+        # specialist tasks emit the warning deterministically (the cost value
+        # itself is unaffected — it always uses the default rate here).
+        with _WARNED_LOCK:
+            if model not in _WARNED_UNKNOWN_MODELS:
+                _WARNED_UNKNOWN_MODELS.add(model)
+                logger.warning(
+                    "No pricing for model %r — estimating at default (Sonnet-shaped) rates. "
+                    "Set DD_MODEL_PRICING to cost it accurately.",
+                    model,
+                )
     return (input_tokens * pricing["input"] + output_tokens * pricing["output"]) / 1_000_000
 
 
@@ -239,6 +245,14 @@ class CostTracker:
             result[e.step] += e.cost_usd
         return dict(result)
 
+    def models_used(self) -> list[str]:
+        """Return the distinct, non-empty model ids recorded across the run.
+
+        Sorted for determinism. Used to stamp the run's audit receipt with the
+        models that actually produced the analysis.
+        """
+        return sorted({e.model for e in self.entries if e.model})
+
     def is_budget_exceeded(self) -> bool:
         """Return True if total cost exceeds the budget limit."""
         if self.budget_limit_usd is None:
@@ -252,12 +266,20 @@ class CostTracker:
         return max(0.0, self.budget_limit_usd - self.total_cost())
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize the tracker state for reporting."""
+        """Serialize the tracker state for reporting.
+
+        Includes the active LLM routing receipt (provider + secret-free
+        base_url + distinct models used) so cost_summary.json is a
+        self-contained audit artifact: what was spent AND on which provider/model.
+        """
+        from dd_agents.llm import resolve_provider
+
         return {
             "total_cost": round(self.total_cost(), 4),
             "total_tokens": self.total_tokens(),
             "budget_limit_usd": self.budget_limit_usd,
             "budget_remaining": round(self.remaining_budget(), 4) if self.budget_limit_usd else None,
+            "routing": {**resolve_provider().as_receipt(), "models_used": self.models_used()},
             "by_agent": {k: round(v, 4) for k, v in self.cost_by_agent().items()},
             "by_step": {k: round(v, 4) for k, v in self.cost_by_step().items()},
             "entries": [e.model_dump() for e in self.entries],

--- a/src/dd_agents/cli.py
+++ b/src/dd_agents/cli.py
@@ -301,6 +301,14 @@ def run(
         run_options["no_knowledge"] = True
     if no_narrative:
         run_options["no_narrative"] = True
+    # Plumb model selection so the engine applies it to the effective config
+    # (and folds it into the provenance hash) — see engine._step_01. Source the
+    # already-validated values off deal_config.agent_models rather than re-parsing
+    # the raw flags, so CLI validation is the single source of truth.
+    if model_profile is not None:
+        run_options["model_profile"] = deal_config.agent_models.profile
+    if model_overrides:
+        run_options["model_overrides"] = dict(deal_config.agent_models.overrides)
 
     console.print()
     console.print(
@@ -473,6 +481,109 @@ def version(as_json: bool) -> None:
         click.echo(json.dumps({"version": dd_agents.__version__}))
     else:
         console.print(f"dd-agents {dd_agents.__version__}")
+
+
+# ---------------------------------------------------------------------------
+# doctor command — verify the LLM provider/model routing before a full run
+# ---------------------------------------------------------------------------
+
+# Which credential env var(s) each provider needs present. Bedrock/Vertex
+# accept either a profile or explicit keys; we check the common ones.
+_PROVIDER_CREDENTIAL_HINTS: dict[str, tuple[str, ...]] = {
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "bedrock": ("AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_BEARER_TOKEN_BEDROCK"),
+    "vertex": ("ANTHROPIC_VERTEX_PROJECT_ID", "GOOGLE_APPLICATION_CREDENTIALS"),
+    "gateway": ("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"),
+}
+
+
+@main.command()
+@click.option(
+    "--probe", is_flag=True, default=False, help="Issue a minimal live query through the configured provider."
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output the routing receipt as JSON.")
+def doctor(probe: bool, as_json: bool) -> None:
+    """Verify the configured LLM provider/model routing (no pipeline run).
+
+    Shows which provider/gateway will answer (secret-free), checks that a
+    credential for it is present, and — with ``--probe`` — issues one minimal
+    live query to confirm the endpoint actually responds. Use this to validate
+    a Bedrock / Vertex / gateway setup before committing to a full run.
+    """
+    import os
+
+    from dd_agents.llm import resolve_provider
+
+    info = resolve_provider()
+    receipt = info.as_receipt()
+    hints = _PROVIDER_CREDENTIAL_HINTS.get(info.provider, ())
+    credential_present = any(os.getenv(name) for name in hints)
+
+    probe_ok: bool | None = None
+    probe_detail = ""
+    if probe:
+        probe_ok, probe_detail = _probe_provider()
+
+    if as_json:
+        out: dict[str, Any] = {**receipt, "credential_present": credential_present}
+        if probe:
+            out["probe_ok"] = probe_ok
+            out["probe_detail"] = probe_detail
+        click.echo(json.dumps(out))
+        if (probe and not probe_ok) or not credential_present:
+            raise SystemExit(1)
+        return
+
+    lines = [
+        f"[bold]Provider:[/bold] {info.provider}",
+        f"[bold]Model:[/bold] {receipt.get('base_url') and 'gateway-served' or 'provider default / per-config'}",
+    ]
+    if receipt.get("base_url"):
+        lines.append(f"[bold]Gateway:[/bold] {receipt['base_url']}")
+    if info.max_output_tokens is not None:
+        lines.append(f"[bold]Output-token clamp:[/bold] {info.max_output_tokens}")
+    cred_color = "green" if credential_present else "yellow"
+    cred_text = "present" if credential_present else f"NOT found (looked for: {', '.join(hints) or 'n/a'})"
+    lines.append(f"[bold]Credential:[/bold] [{cred_color}]{cred_text}[/{cred_color}]")
+    if probe:
+        probe_color = "green" if probe_ok else "red"
+        lines.append(f"[bold]Live probe:[/bold] [{probe_color}]{'OK' if probe_ok else 'FAILED'}[/{probe_color}]")
+        if probe_detail:
+            lines.append(f"  {probe_detail}")
+
+    border = "green" if credential_present and (probe_ok is not False) else "yellow"
+    console.print(Panel("\n".join(lines), title="LLM Provider Routing", border_style=border))
+    if not credential_present:
+        console.print(
+            "[yellow]No credential detected for this provider. "
+            "Set the appropriate env var — see docs/user-guide/model-providers.md.[/yellow]"
+        )
+    if (probe and not probe_ok) or not credential_present:
+        raise SystemExit(1)
+
+
+def _probe_provider() -> tuple[bool, str]:
+    """Issue one minimal query through the seam. Returns (ok, detail)."""
+    import asyncio
+
+    async def _run() -> tuple[bool, str]:
+        try:
+            from claude_agent_sdk import query
+
+            from dd_agents.llm import build_agent_options
+
+            options = build_agent_options(max_turns=1)
+            text = ""
+            async for message in query(prompt="Reply with the single word: OK", options=options):
+                for attr in ("content", "result", "text"):
+                    val = getattr(message, attr, None)
+                    if isinstance(val, str):
+                        text += val
+            return (bool(text.strip()), f"response chars: {len(text.strip())}")
+        except Exception as exc:  # noqa: BLE001 — diagnostic surface, report any failure
+            return (False, f"{type(exc).__name__}: {exc}")
+
+    return asyncio.run(_run())
 
 
 # ---------------------------------------------------------------------------

--- a/src/dd_agents/extraction/glm_ocr.py
+++ b/src/dd_agents/extraction/glm_ocr.py
@@ -27,6 +27,7 @@ vs bf16) had minimal impact on accuracy.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import tempfile
 import threading
@@ -39,8 +40,11 @@ from dd_agents.extraction._constants import CONFIDENCE_GLM_OCR as _CONFIDENCE_GL
 logger = logging.getLogger(__name__)
 
 # ── Tuning constants (benchmarked on Apple M3 Max) ───────────────────
-MODEL_ID_MLX = "mlx-community/GLM-OCR-8bit"
-MODEL_ID_OLLAMA = "glm-ocr"
+# Local VLM model tags. Override to point OCR at a different local model
+# (e.g. a newer GLM-OCR build or a differently-tagged Ollama model), mirroring
+# the DD_TRANSCRIPTION_MODEL knob on the sibling transcription path.
+MODEL_ID_MLX = os.getenv("DD_OCR_MODEL_MLX") or "mlx-community/GLM-OCR-8bit"
+MODEL_ID_OLLAMA = os.getenv("DD_OCR_MODEL_OLLAMA") or "glm-ocr"
 MAX_TOKENS = 2048
 DPI = 200
 MAX_IMAGE_DIM = 1024

--- a/src/dd_agents/extraction/ocr_registry.py
+++ b/src/dd_agents/extraction/ocr_registry.py
@@ -15,12 +15,46 @@ Set ``extraction.ocr_backend`` in deal-config.json:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from dd_agents.extraction.backend import ExtractionBackend
+    from dd_agents.extraction.pipeline import ExtractionPipeline
 
 logger = logging.getLogger(__name__)
+
+
+def _ocr_preference_from_config(deal_config: Any) -> str:
+    """Extract ``extraction.ocr_backend`` from a raw-dict or typed deal config.
+
+    Returns ``"auto"`` when unset or unreadable.
+    """
+    if isinstance(deal_config, dict):
+        extraction_cfg = deal_config.get("extraction", {})
+        if isinstance(extraction_cfg, dict):
+            value = extraction_cfg.get("ocr_backend", "auto")
+            return str(value) if value else "auto"
+        return "auto"
+    extraction = getattr(deal_config, "extraction", None)
+    return str(getattr(extraction, "ocr_backend", "auto") or "auto")
+
+
+def build_extraction_pipeline(deal_config: Any = None) -> ExtractionPipeline:
+    """Build an ``ExtractionPipeline`` with the config-selected OCR backend.
+
+    The ONE seam for OCR-backend selection: reads ``extraction.ocr_backend``
+    from the deal config (raw dict or typed), resolves it through
+    :meth:`OCRBackendRegistry.get_backend`, and wires a GLM-OCR backend into the
+    pipeline only when one is actually available — otherwise the pipeline relies
+    on its built-in pytesseract path. Both the orchestrator and the standalone
+    search command call this so OCR selection can never drift between them.
+    """
+    from dd_agents.extraction.glm_ocr import GlmOcrExtractor
+    from dd_agents.extraction.pipeline import ExtractionPipeline
+
+    preference = _ocr_preference_from_config(deal_config)
+    backend = OCRBackendRegistry.get_backend(preference)
+    return ExtractionPipeline(glm_ocr=backend if isinstance(backend, GlmOcrExtractor) else None)
 
 
 class OCRBackendRegistry:

--- a/src/dd_agents/llm/provider.py
+++ b/src/dd_agents/llm/provider.py
@@ -44,14 +44,58 @@ class ProviderInfo:
     #: Output-token clamp in effect (None when unset).
     max_output_tokens: int | None
 
+    @property
+    def safe_base_url(self) -> str | None:
+        """``base_url`` with any embedded credentials stripped.
+
+        ``ANTHROPIC_BASE_URL`` can legitimately carry secrets in userinfo
+        (``https://token@host``) or a query string (``?api-key=...``). This
+        keeps only scheme + host[:port] + path so the value is safe to log and
+        persist. Returns None when no base_url is set.
+        """
+        if not self.base_url:
+            return None
+        from urllib.parse import urlsplit, urlunsplit
+
+        parts = urlsplit(self.base_url)
+        host = parts.hostname or ""
+        if parts.port:
+            host = f"{host}:{parts.port}"
+        # Drop userinfo (netloc → host only), query, and fragment.
+        return urlunsplit((parts.scheme, host, parts.path, "", "")) or None
+
     def describe(self) -> str:
         """One-line, secret-free summary for startup logging."""
         parts = [f"provider={self.provider}"]
-        if self.base_url:
-            parts.append(f"base_url={self.base_url}")
+        safe = self.safe_base_url
+        if safe:
+            parts.append(f"base_url={safe}")
         if self.max_output_tokens is not None:
             parts.append(f"max_output_tokens={self.max_output_tokens}")
         return " ".join(parts)
+
+    def as_receipt(self) -> dict[str, str | int | None]:
+        """Secret-free routing receipt for persistence into the run audit trail."""
+        return {
+            "provider": self.provider,
+            "base_url": self.safe_base_url,
+            "max_output_tokens": self.max_output_tokens,
+        }
+
+    def fingerprint(self) -> str:
+        """Stable, secret-free identity of the active routing.
+
+        Folded into the provenance hash so a resume under a different
+        provider/gateway/clamp is rejected by the fail-closed gate. Uses the
+        redacted base_url (host only), so no secret enters the hash.
+        """
+        return "|".join(
+            (
+                self.provider,
+                self.safe_base_url or "",
+                str(self.max_output_tokens if self.max_output_tokens is not None else ""),
+            )
+        )
 
 
 def _max_output_tokens() -> int | None:

--- a/src/dd_agents/models/persistence.py
+++ b/src/dd_agents/models/persistence.py
@@ -25,6 +25,15 @@ class RunMetadata(BaseModel):
     execution_mode: ExecutionMode = Field(description="Execution mode: 'full' or 'incremental'")
     config_hash: str = Field(description="SHA-256 hash of deal-config.json")
     framework_version: str = Field(default="unknown", description="Version of the dd-agents framework")
+    # LLM routing receipt (audit): which provider/gateway answered. Secret-free
+    # (base_url is host-only). Empty/None when not recorded (older runs).
+    llm_provider: str | None = Field(
+        default=None, description="Active LLM provider: anthropic | bedrock | vertex | gateway"
+    )
+    llm_base_url: str | None = Field(
+        default=None, description="Gateway base URL (host only, credentials stripped), if any"
+    )
+    llm_models: list[str] = Field(default_factory=list, description="Distinct model ids actually used across the run")
     cross_skill_run_ids: dict[str, str] = Field(
         default_factory=dict, description="Map of skill name to run_id for cross-skill data"
     )

--- a/src/dd_agents/orchestrator/engine.py
+++ b/src/dd_agents/orchestrator/engine.py
@@ -95,6 +95,9 @@ class PipelineEngine:
         self.checkpoint_dir = self.project_dir / "_dd" / "forensic-dd" / "checkpoints"
         self.team: AgentTeam | None = None
         self._run_options: dict[str, Any] = {}
+        # Cache of the typed DealConfig built from the effective (CLI-override
+        # applied) raw config. None until first built; reset when raw changes.
+        self._typed_deal_config_cache: tuple[int, Any] | None = None
 
         from dd_agents.agents.cost_tracker import CostTracker
         from dd_agents.agents.registry import AgentRegistry
@@ -237,6 +240,7 @@ class PipelineEngine:
             if stored_provenance:
                 from dd_agents.agents.prompt_builder import PromptBuilder
                 from dd_agents.agents.registry import AgentRegistry as _Reg
+                from dd_agents.llm import resolve_provider as _rp
                 from dd_agents.persistence.provenance import (
                     compute_persona_hashes as _cph,
                 )
@@ -251,14 +255,16 @@ class PipelineEngine:
                     # project_dir folds dd-config/ drift into the recompute too,
                     # matching VALIDATE_CONFIG (Copilot #202 C5).
                     _cph(_Reg.collect_persona_texts(_active, project_dir=self.project_dir)),
+                    # Routing fingerprint: a provider/gateway swap busts the gate.
+                    _rp().fingerprint(),
                 )
                 if _current != stored_provenance:
                     raise BlockingGateError(
-                        "Resume blocked: deal config or agent personas/prompts changed "
-                        "since this checkpoint (provenance hash mismatch). Resuming would "
-                        "pair stale results with new instructions and break reproducibility. "
-                        "Delete the checkpoint directory or re-run without --resume-from to "
-                        "start fresh."
+                        "Resume blocked: deal config, agent personas/prompts, or LLM "
+                        "provider/model routing changed since this checkpoint (provenance "
+                        "hash mismatch). Resuming would pair stale results with new "
+                        "instructions/backends and break reproducibility. Delete the "
+                        "checkpoint directory or re-run without --resume-from to start fresh."
                     )
                 logger.info("Provenance gate passed — checkpoint matches current config/personas.")
             elif resume_from_step > 1:
@@ -709,6 +715,22 @@ class PipelineEngine:
         except Exception as exc:
             raise BlockingGateError(f"Config validation failed: {exc}") from exc
 
+        # Apply CLI model selection onto the effective config BEFORE hashing, so
+        # --model-profile / --model-override are (a) honored by the agents and
+        # (b) folded into the provenance hash. Mutating the raw dict keeps a
+        # single source of truth: state.deal_config, the typed load, and the hash
+        # all see the same effective config.
+        agent_models_raw = raw.setdefault("agent_models", {})
+        profile_override = self._run_options.get("model_profile")
+        if profile_override:
+            agent_models_raw["profile"] = profile_override
+            logger.info("Model profile overridden by CLI: %s", profile_override)
+        model_overrides = self._run_options.get("model_overrides")
+        if model_overrides:
+            merged = {**agent_models_raw.get("overrides", {}), **model_overrides}
+            agent_models_raw["overrides"] = merged
+            logger.info("Per-agent model overrides applied by CLI: %s", model_overrides)
+
         state.deal_config = raw
         # Provenance (audit §8.1): one canonical config hash (not raw bytes, so
         # it matches the resume-recompute and run_manager), plus prompt version +
@@ -730,7 +752,17 @@ class PipelineEngine:
         state.persona_hashes = compute_persona_hashes(
             AgentRegistry.collect_persona_texts(active_agents, project_dir=self.project_dir)
         )
-        state.provenance_hash = compute_provenance_hash(state.config_hash, state.prompt_version, state.persona_hashes)
+        # Fold the secret-free LLM routing fingerprint into provenance so a
+        # resume under a different provider/gateway/clamp is rejected (no
+        # silent cross-backend stitching).
+        from dd_agents.llm import resolve_provider
+
+        state.provenance_hash = compute_provenance_hash(
+            state.config_hash,
+            state.prompt_version,
+            state.persona_hashes,
+            resolve_provider().fingerprint(),
+        )
 
         # Pull execution settings from config
         execution = raw.get("execution", {})
@@ -744,13 +776,15 @@ class PipelineEngine:
             state.execution_mode = mode_override
             logger.info("Execution mode overridden by CLI: %s", mode_override)
 
-        # Refine active agents now that the typed config is available.
+        # Refine active agents now that the typed config is available. Use the
+        # effective in-memory config (single source of truth) rather than a
+        # fresh disk read.
         try:
             from dd_agents.agents.registry import AgentRegistry
-            from dd_agents.config import load_deal_config
 
-            deal_cfg = load_deal_config(self.deal_config_path)
-            self._active_agents = AgentRegistry.resolve_active(deal_cfg)
+            deal_cfg = self._typed_deal_config(state)
+            if deal_cfg is not None:
+                self._active_agents = AgentRegistry.resolve_active(deal_cfg)
         except Exception as exc:
             logger.debug("Could not refine active agents from config: %s", exc)
 
@@ -763,6 +797,33 @@ class PipelineEngine:
             self._active_agents,
         )
         return state
+
+    def _typed_deal_config(self, state: PipelineState) -> Any:
+        """Return the typed ``DealConfig`` built from the EFFECTIVE raw config.
+
+        Single source of truth for model selection across every agent the
+        engine constructs (synthesis, judge, etc.). Built from
+        ``state.deal_config`` — the raw dict with CLI ``--model-profile`` /
+        ``--model-override`` already applied in ``_step_01`` — rather than
+        re-reading the on-disk file, so the overrides are honored and provenance
+        stays consistent. Cached against the raw object's identity so a resume
+        that swaps the dict rebuilds it.
+        """
+        raw = state.deal_config
+        if not isinstance(raw, dict):
+            return None
+        cache = self._typed_deal_config_cache
+        if cache is not None and cache[0] == id(raw):
+            return cache[1]
+        typed: Any = None
+        try:
+            from dd_agents.models.config import DealConfig
+
+            typed = DealConfig.model_validate(raw)
+        except Exception as exc:  # noqa: BLE001 — config already validated in _step_01
+            logger.debug("Could not build typed deal config: %s", exc)
+        self._typed_deal_config_cache = (id(raw), typed)
+        return typed
 
     async def _step_02_init_persistence(self, state: PipelineState) -> PipelineState:
         """Generate run_id, create directory structure, wipe FRESH tier.
@@ -867,7 +928,7 @@ class PipelineEngine:
 
     async def _step_05_bulk_extraction(self, state: PipelineState) -> PipelineState:
         """Bulk pre-extraction of text from documents.  BLOCKING GATE."""
-        from dd_agents.extraction.pipeline import ExtractionPipeline, ExtractionPipelineError
+        from dd_agents.extraction.pipeline import ExtractionPipelineError
 
         files = getattr(state, "_discovered_files", [])
         if not files:
@@ -882,22 +943,11 @@ class PipelineEngine:
         # Resolve file paths to absolute
         file_paths = [str(state.project_dir / entry.path) for entry in files]
 
-        # Select OCR backend from deal-config (Issue #2)
-        ocr_preference = "auto"
-        if state.deal_config and isinstance(state.deal_config, dict):
-            extraction_cfg = state.deal_config.get("extraction", {})
-            if isinstance(extraction_cfg, dict):
-                ocr_preference = extraction_cfg.get("ocr_backend", "auto")
+        # Select OCR backend from deal-config (Issue #2) via the shared seam so
+        # the orchestrator and the standalone search command never diverge.
+        from dd_agents.extraction.ocr_registry import build_extraction_pipeline
 
-        from dd_agents.extraction.ocr_registry import OCRBackendRegistry
-
-        ocr_backend = OCRBackendRegistry.get_backend(ocr_preference)
-
-        from dd_agents.extraction.glm_ocr import GlmOcrExtractor
-
-        # Pass registry-selected GLM-OCR backend if available; otherwise
-        # None so the pipeline relies on its default pytesseract OCR.
-        pipeline = ExtractionPipeline(glm_ocr=ocr_backend if isinstance(ocr_backend, GlmOcrExtractor) else None)
+        pipeline = build_extraction_pipeline(state.deal_config)
         try:
             pipeline.extract_all(
                 files=file_paths,
@@ -1245,16 +1295,10 @@ class PipelineEngine:
         reference_files: list[Any] = getattr(state, "_reference_files", [])
         deal_config_raw = state.deal_config
 
-        # Lazy import to build typed DealConfig only when available
-        deal_config_obj: Any = None
-        if deal_config_raw:
-            try:
-                from dd_agents.config import load_deal_config
-
-                deal_config_obj = load_deal_config(self.deal_config_path)
-            except Exception as exc:
-                logger.warning("Failed to load deal config for prompt enrichment: %s", exc)
-                deal_config_obj = None
+        # Build typed DealConfig from the effective in-memory config (CLI
+        # overrides applied), not the on-disk file, so prompt enrichment and
+        # model selection stay consistent with the rest of the run.
+        deal_config_obj: Any = self._typed_deal_config(state) if deal_config_raw else None
 
         run_dir = state.run_dir or (state.project_dir / state.skill_dir / "runs" / state.run_id)
         builder = PromptBuilder(
@@ -2619,6 +2663,7 @@ class PipelineEngine:
                 project_dir=state.project_dir,
                 run_dir=state.run_dir,
                 run_id=state.run_id,
+                deal_config=self._typed_deal_config(state),
             )
             # Apply deal-config overrides
             judge.score_threshold = judge_config.get("score_threshold", DEFAULT_SCORE_THRESHOLD)
@@ -3412,10 +3457,18 @@ class PipelineEngine:
         Collects quality_scores, entity_matches, reference_files, and
         run-level statistics so conditional sheets have data to render.
         """
+        from dd_agents.llm import resolve_provider
+
+        routing = resolve_provider().as_receipt()
         run_metadata: dict[str, Any] = {
             "run_id": state.run_id,
             "execution_mode": state.execution_mode,
             "framework_version": state.framework_version,
+            # Generation provenance (secret-free): which provider/model produced
+            # the analysis, for enterprise audit/governance review.
+            "llm_provider": routing["provider"],
+            "llm_base_url": routing["base_url"],
+            "llm_models": (ct.models_used() if (ct := getattr(self, "cost_tracker", None)) else []),
         }
 
         inv_dir = self._inventory_dir(state)
@@ -3633,6 +3686,7 @@ class PipelineEngine:
                 project_dir=self.project_dir,
                 run_dir=state.run_dir,
                 run_id=state.run_id,
+                deal_config=self._typed_deal_config(state),
             )
             # Collect P0 and P1 findings from merged data.
             # Apply severity recalibration so the agent sees the same
@@ -3728,6 +3782,7 @@ class PipelineEngine:
                     project_dir=self.project_dir,
                     run_dir=state.run_dir,
                     run_id=state.run_id,
+                    deal_config=self._typed_deal_config(state),
                 )
                 ai_state = {
                     "buyer_strategy": deal_config_dict["buyer_strategy"],
@@ -3770,6 +3825,7 @@ class PipelineEngine:
                     project_dir=self.project_dir,
                     run_dir=state.run_dir,
                     run_id=state.run_id,
+                    deal_config=self._typed_deal_config(state),
                 )
                 rf_state: dict[str, Any] = {
                     "merged_findings_dir": str(state.run_dir / "findings" / "merged"),
@@ -3797,6 +3853,7 @@ class PipelineEngine:
                     project_dir=self.project_dir,
                     run_dir=state.run_dir,
                     run_id=state.run_id,
+                    deal_config=self._typed_deal_config(state),
                 )
 
                 # Build domain summaries from severity distribution
@@ -3969,6 +4026,12 @@ class PipelineEngine:
         subject_assignments = self._collect_subject_assignments(state)
         batch_counts = getattr(state, "batch_counts", {}) or {}
 
+        # LLM routing receipt (secret-free): which provider/gateway answered and
+        # the distinct models actually used — recorded in the durable run record.
+        from dd_agents.llm import resolve_provider
+
+        routing = resolve_provider().as_receipt()
+
         metadata = RunMetadata(
             run_id=state.run_id,
             timestamp=state.run_dir.name if state.run_dir else state.run_id,
@@ -3976,6 +4039,9 @@ class PipelineEngine:
             execution_mode=ExecutionMode(state.execution_mode),
             config_hash=state.config_hash,
             framework_version=state.framework_version,
+            llm_provider=routing["provider"],  # type: ignore[arg-type]
+            llm_base_url=routing["base_url"],  # type: ignore[arg-type]
+            llm_models=self.cost_tracker.models_used(),
             completion_status=CompletionStatus.COMPLETED,
             finding_counts=finding_counts,
             gap_counts=gap_counts,

--- a/src/dd_agents/orchestrator/team.py
+++ b/src/dd_agents/orchestrator/team.py
@@ -13,7 +13,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from dd_agents.agents.registry import AgentRegistry
 from dd_agents.utils.constants import (
@@ -22,6 +22,7 @@ from dd_agents.utils.constants import (
 )
 
 if TYPE_CHECKING:
+    from dd_agents.models.config import DealConfig
     from dd_agents.orchestrator.state import PipelineState
 
 logger = logging.getLogger(__name__)
@@ -82,6 +83,32 @@ class AgentTeam:
         self._completed_agents: set[str] = set()
         # Per-batch SDK turn counts: "commercial_b1" → turn_number
         self._batch_turns: dict[str, int] = {}
+        # Typed deal config, built once from the (CLI-override-applied) raw
+        # state.deal_config so specialist runners resolve agent_models / model
+        # overrides. Cached: parsed lazily on first access. ``False`` sentinel
+        # distinguishes "not yet built" from a successfully-parsed ``None``.
+        self._typed_deal_config: DealConfig | None | Literal[False] = False
+
+    def _deal_config(self) -> DealConfig | None:
+        """Return the typed deal config parsed from ``state.deal_config``.
+
+        The runners need a typed ``DealConfig`` to resolve model selection via
+        ``agent_models`` (profile + per-agent overrides). ``state.deal_config``
+        is the raw dict with CLI overrides already applied (see
+        ``engine._step_01``), so parsing it here keeps a single source of truth
+        and honors ``--model-profile`` / ``--model-override``.
+        """
+        if self._typed_deal_config is False:
+            self._typed_deal_config = None
+            raw = self.state.deal_config
+            if isinstance(raw, dict):
+                try:
+                    from dd_agents.models.config import DealConfig as _DealConfig
+
+                    self._typed_deal_config = _DealConfig.model_validate(raw)
+                except Exception as exc:  # noqa: BLE001 — config already validated upstream
+                    logger.debug("Could not build typed deal config for model resolution: %s", exc)
+        return self._typed_deal_config
 
     # ------------------------------------------------------------------
     # Specialist agents
@@ -283,6 +310,7 @@ class AgentTeam:
                 project_dir=self.state.project_dir,
                 run_dir=self.state.run_dir,
                 run_id=self.state.run_id,
+                deal_config=self._deal_config(),
             )
             runner.batch_label = batch_label
             if runner_kwargs.get("max_turns"):
@@ -385,11 +413,20 @@ class AgentTeam:
         # Estimate cost from token counts
         from dd_agents.agents.cost_tracker import _estimate_cost
 
+        # Resolve the effective model id the SAME way the runner does (typed
+        # deal config → agent_models), so cost is attributed to the real model
+        # rather than blank. Falls back to the registry's default model when no
+        # selection is configured, so a run is never costed against "".
         model_id = ""
         if runner_cls is not None:
             try:
-                _tmp = runner_cls.__new__(runner_cls)  # type: ignore[call-overload]
-                model_id = (_tmp.get_model_id() if hasattr(_tmp, "get_model_id") else "") or ""
+                _tmp = runner_cls(
+                    project_dir=self.state.project_dir,
+                    run_dir=self.state.run_dir,
+                    run_id=self.state.run_id,
+                    deal_config=self._deal_config(),
+                )
+                model_id = (_tmp.get_model_id() if hasattr(_tmp, "get_model_id") else None) or ""
             except Exception:  # noqa: BLE001
                 pass
         cost_usd = _estimate_cost(model_id, total_input_tokens, total_output_tokens)
@@ -430,6 +467,7 @@ class AgentTeam:
             project_dir=self.state.project_dir,
             run_dir=self.state.run_dir,
             run_id=self.state.run_id,
+            deal_config=self._deal_config(),
         )
 
         agent_state: dict[str, Any] = {

--- a/src/dd_agents/persistence/provenance.py
+++ b/src/dd_agents/persistence/provenance.py
@@ -62,17 +62,26 @@ def compute_provenance_hash(
     config_hash: str,
     prompt_version: str,
     persona_hashes: dict[str, str],
+    routing_fingerprint: str = "",
 ) -> str:
     """Combine config + prompt-version + persona hashes into one provenance hash.
 
     This is the value the fail-closed resume gate compares: if the config, the
-    prompt builder version, or any agent persona changed since the checkpoint,
-    the combined hash changes and the stale checkpoint is rejected.
+    prompt builder version, any agent persona, or the LLM routing
+    (provider/gateway/clamp — ``routing_fingerprint``) changed since the
+    checkpoint, the combined hash changes and the stale checkpoint is rejected.
+    So a run cannot silently resume under a different provider/model and stitch
+    findings from two backends into one report.
+
+    ``routing_fingerprint`` defaults to ``""`` so the function stays pure (the
+    caller derives the secret-free fingerprint from the environment and passes
+    it in); an empty value preserves the legacy three-input hash.
     """
     payload = {
         "config_hash": config_hash,
         "prompt_version": prompt_version,
         "persona_hashes": dict(sorted(persona_hashes.items())),
+        "routing_fingerprint": routing_fingerprint,
     }
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/src/dd_agents/persistence/run_manager.py
+++ b/src/dd_agents/persistence/run_manager.py
@@ -175,6 +175,12 @@ class RunManager:
         if fw_path.exists():
             framework_version = fw_path.read_text(encoding="utf-8").strip()
 
+        # Record the active LLM routing (secret-free) so the durable run record
+        # shows which provider/gateway produced the analysis (enterprise audit).
+        from dd_agents.llm import resolve_provider
+
+        routing = resolve_provider().as_receipt()
+
         metadata = RunMetadata(
             run_id=run_id,
             timestamp=datetime.now(UTC).isoformat(),
@@ -182,6 +188,8 @@ class RunManager:
             execution_mode=exec_mode,
             config_hash=config_hash,
             framework_version=framework_version,
+            llm_provider=routing["provider"],  # type: ignore[arg-type]
+            llm_base_url=routing["base_url"],  # type: ignore[arg-type]
             completion_status=CompletionStatus.IN_PROGRESS,
         )
 

--- a/src/dd_agents/reporting/html_methodology.py
+++ b/src/dd_agents/reporting/html_methodology.py
@@ -29,6 +29,29 @@ class MethodologyRenderer(SectionRenderer):
             "quality gates.</p>"
         )
 
+        # Generation provenance (secret-free): which provider/model produced the
+        # analysis, for audit/governance review. Sourced from the persisted run
+        # metadata routing receipt (see RunMetadata.llm_*).
+        run_meta = (self.config or {}).get("_run_metadata") or {}
+        if isinstance(run_meta, dict):
+            provider = run_meta.get("llm_provider")
+            models = run_meta.get("llm_models") or []
+            base_url = run_meta.get("llm_base_url")
+            if provider or models:
+                items: list[str] = []
+                if provider:
+                    items.append(f"<li>Provider: <strong>{self.escape(str(provider))}</strong></li>")
+                if models:
+                    model_str = ", ".join(self.escape(str(m)) for m in models)
+                    items.append(f"<li>Model(s): <strong>{model_str}</strong></li>")
+                if base_url:
+                    items.append(f"<li>Gateway: <strong>{self.escape(str(base_url))}</strong></li>")
+                parts.append("<h3>Generation Provenance</h3>")
+                parts.append(
+                    "<p>The findings in this report were produced by the following model/provider configuration:</p>"
+                )
+                parts.append("<ul>" + "".join(items) + "</ul>")
+
         # Key stats
         parts.append(
             "<div class='metrics-strip'>"

--- a/src/dd_agents/search/analyzer.py
+++ b/src/dd_agents/search/analyzer.py
@@ -58,8 +58,6 @@ logger = logging.getLogger(__name__)
 
 # Approximate tokens per character for cost estimation.
 _CHARS_PER_TOKEN = 4
-_INPUT_COST_PER_MTOK = 3.0  # Claude Sonnet 4 pricing (USD per 1M tokens)
-_OUTPUT_COST_PER_MTOK = 15.0
 
 # Error messages that indicate non-transient failures (don't retry).
 _NON_TRANSIENT_ERRORS = ("Prompt is too long", "context length", "too many tokens")
@@ -279,10 +277,13 @@ class SearchAnalyzer:
         # Rough output estimate: ~500 tokens per column per subject.
         estimated_output_tokens = len(subjects) * len(self._prompts.columns) * 500
 
-        estimated_cost = (
-            estimated_input_tokens / 1_000_000 * _INPUT_COST_PER_MTOK
-            + estimated_output_tokens / 1_000_000 * _OUTPUT_COST_PER_MTOK
-        )
+        # Cost the search model through the single shared pricing seam so a
+        # gateway/non-Claude search model (DD_SEARCH_MODEL) is costed consistently
+        # with the rest of the system and honors DD_MODEL_PRICING.
+        from dd_agents.agents.cost_tracker import _estimate_cost
+
+        search_model = os.getenv("DD_SEARCH_MODEL", "")
+        estimated_cost = _estimate_cost(search_model, estimated_input_tokens, estimated_output_tokens)
 
         return {
             "total_subjects": len(subjects),

--- a/src/dd_agents/search/runner.py
+++ b/src/dd_agents/search/runner.py
@@ -161,10 +161,12 @@ class SearchRunner:
 
         if relevant_file_paths:
             self._console.print("\n[bold]Running text extraction...[/bold]")
-            from dd_agents.extraction.glm_ocr import GlmOcrExtractor
-            from dd_agents.extraction.pipeline import ExtractionPipeline
+            from dd_agents.extraction.ocr_registry import build_extraction_pipeline
 
-            pipeline = ExtractionPipeline(glm_ocr=GlmOcrExtractor())
+            # Auto-detect the OCR backend (no deal config in the search path) via
+            # the same seam the pipeline uses, so a machine without mlx-vlm/ollama
+            # does not force an unavailable GLM-OCR backend.
+            pipeline = build_extraction_pipeline()
             pipeline.extract_all(
                 files=relevant_file_paths,
                 output_dir=text_dir,

--- a/src/dd_agents/tools/extract_document.py
+++ b/src/dd_agents/tools/extract_document.py
@@ -92,10 +92,14 @@ def extract_document(
     # and get_page_content look up files by whatever source_path the agent
     # passes — typically a relative or bare path.  To bridge the gap we
     # write the extracted text under every plausible lookup name.
+    from dd_agents.extraction.ocr_registry import build_extraction_pipeline
     from dd_agents.extraction.pipeline import ExtractionPipeline
 
     try:
-        pipeline = ExtractionPipeline()
+        # Shared OCR seam (auto-detect; no deal config in the on-demand tool path)
+        # so single-document extraction gets GLM-OCR when available, matching the
+        # bulk pipeline instead of silently falling back to pytesseract-only.
+        pipeline = build_extraction_pipeline()
         text_out.mkdir(parents=True, exist_ok=True)
 
         entry = pipeline.extract_single(filepath=resolved, output_dir=text_out)

--- a/tests/unit/test_agnosticism_system.py
+++ b/tests/unit/test_agnosticism_system.py
@@ -1,0 +1,273 @@
+"""System-wide model/provider-agnosticism contracts (audit follow-up).
+
+Covers the fixes that make agnosticism work end-to-end, not just in the
+reasoning seam:
+
+- CLI ``--model-profile`` / ``--model-override`` reach the engine and the
+  effective config (the high-severity "silently dropped" bug).
+- Specialist/synthesis runners receive the typed deal config so model
+  selection is honored and cost is attributed to a real model.
+- One shared OCR-pipeline factory (no per-call-site drift).
+- ``ProviderInfo`` redacts credentials and exposes a persistable receipt.
+- The run's audit trail records the active provider/model.
+- Search cost estimation routes through the single pricing seam.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# ProviderInfo: secret redaction + persistable receipt
+# ---------------------------------------------------------------------------
+
+
+class TestProviderReceipt:
+    def test_safe_base_url_strips_userinfo_and_query(self) -> None:
+        from dd_agents.llm.provider import ProviderInfo
+
+        info = ProviderInfo(
+            provider="gateway",
+            base_url="https://tok:s3cret@host.example.com:4011/v1?api-key=abc",  # pragma: allowlist secret
+            max_output_tokens=4096,
+        )
+        safe = info.safe_base_url
+        assert safe == "https://host.example.com:4011/v1"
+        assert "s3cret" not in (safe or "")
+        assert "api-key" not in (safe or "")
+
+    def test_describe_is_secret_free(self) -> None:
+        from dd_agents.llm.provider import ProviderInfo
+
+        info = ProviderInfo(
+            provider="gateway",
+            base_url="https://user:pw@gw.internal/v1",  # pragma: allowlist secret
+            max_output_tokens=None,
+        )
+        text = info.describe()
+        assert "pw@" not in text
+        assert "gw.internal" in text
+
+    def test_safe_base_url_none_when_unset(self) -> None:
+        from dd_agents.llm.provider import ProviderInfo
+
+        info = ProviderInfo(provider="anthropic", base_url=None, max_output_tokens=None)
+        assert info.safe_base_url is None
+
+    def test_fingerprint_changes_with_routing(self) -> None:
+        from dd_agents.llm.provider import ProviderInfo
+
+        anthropic = ProviderInfo(provider="anthropic", base_url=None, max_output_tokens=None)
+        bedrock = ProviderInfo(provider="bedrock", base_url=None, max_output_tokens=None)
+        gateway = ProviderInfo(provider="gateway", base_url="https://gw/v1", max_output_tokens=4096)
+        fps = {anthropic.fingerprint(), bedrock.fingerprint(), gateway.fingerprint()}
+        assert len(fps) == 3  # each routing is distinct
+        # Secret-free: a credentialed base_url never leaks into the fingerprint.
+        creds = ProviderInfo(
+            provider="gateway",
+            base_url="https://tok:sneaky@gw/v1",  # pragma: allowlist secret
+            max_output_tokens=4096,
+        )
+        assert "sneaky" not in creds.fingerprint()
+
+    def test_provenance_hash_folds_routing(self) -> None:
+        from dd_agents.persistence.provenance import compute_provenance_hash
+
+        base = compute_provenance_hash("cfg", "1.0.0", {"legal": "abc"}, "anthropic||")
+        swapped = compute_provenance_hash("cfg", "1.0.0", {"legal": "abc"}, "gateway|https://gw/v1|4096")
+        assert base != swapped  # a provider swap busts the resume gate
+        # Empty fingerprint preserves the legacy 3-input hash for back-compat.
+        legacy = compute_provenance_hash("cfg", "1.0.0", {"legal": "abc"})
+        legacy_explicit = compute_provenance_hash("cfg", "1.0.0", {"legal": "abc"}, "")
+        assert legacy == legacy_explicit
+
+    def test_as_receipt_is_secret_free_dict(self) -> None:
+        from dd_agents.llm.provider import ProviderInfo
+
+        info = ProviderInfo(
+            provider="gateway",
+            base_url="https://k@h.example/v1?token=zzz",  # pragma: allowlist secret
+            max_output_tokens=2048,
+        )
+        receipt = info.as_receipt()
+        assert receipt == {
+            "provider": "gateway",
+            "base_url": "https://h.example/v1",
+            "max_output_tokens": 2048,
+        }
+        assert "zzz" not in json.dumps(receipt)
+
+
+# ---------------------------------------------------------------------------
+# CostTracker: distinct models + routing in to_dict
+# ---------------------------------------------------------------------------
+
+
+class TestCostRoutingReceipt:
+    def test_models_used_distinct_sorted_nonempty(self) -> None:
+        from dd_agents.agents.cost_tracker import CostTracker
+
+        t = CostTracker()
+        t.record("legal", "16_spawn", 100, 50, "claude-opus-4-8")
+        t.record("finance", "16_spawn", 100, 50, "claude-sonnet-4-6")
+        t.record("hr", "16_spawn", 100, 50, "")  # blank ignored
+        t.record("tax", "16_spawn", 100, 50, "claude-opus-4-8")  # dup
+        assert t.models_used() == ["claude-opus-4-8", "claude-sonnet-4-6"]
+
+    def test_to_dict_includes_routing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dd_agents.agents.cost_tracker import CostTracker
+
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_USE_BEDROCK", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_USE_VERTEX", raising=False)
+        t = CostTracker()
+        t.record("legal", "16_spawn", 100, 50, "claude-opus-4-8")
+        d = t.to_dict()
+        assert "routing" in d
+        assert d["routing"]["provider"] == "anthropic"
+        assert d["routing"]["models_used"] == ["claude-opus-4-8"]
+
+
+# ---------------------------------------------------------------------------
+# Shared OCR factory: one seam, config-aware
+# ---------------------------------------------------------------------------
+
+
+class TestOcrFactory:
+    def test_pytesseract_preference_yields_no_glm(self) -> None:
+        from dd_agents.extraction.ocr_registry import build_extraction_pipeline
+
+        pipeline = build_extraction_pipeline({"extraction": {"ocr_backend": "pytesseract"}})
+        # GLM-OCR backend must not be wired when pytesseract is requested.
+        assert pipeline._glm_ocr is None
+
+    def test_preference_from_typed_config(self) -> None:
+        from dd_agents.extraction.ocr_registry import _ocr_preference_from_config
+
+        class _Extraction:
+            ocr_backend = "pytesseract"
+
+        class _Cfg:
+            extraction = _Extraction()
+
+        assert _ocr_preference_from_config(_Cfg()) == "pytesseract"
+
+    def test_preference_defaults_to_auto(self) -> None:
+        from dd_agents.extraction.ocr_registry import _ocr_preference_from_config
+
+        assert _ocr_preference_from_config(None) == "auto"
+        assert _ocr_preference_from_config({}) == "auto"
+
+
+# ---------------------------------------------------------------------------
+# Engine: CLI model selection reaches the effective config + provenance
+# ---------------------------------------------------------------------------
+
+
+def _write_min_config(tmp_path: Path) -> Path:
+    cfg = {
+        "config_version": "1.0.0",
+        "buyer": {"name": "Buyer Co"},
+        "target": {"name": "Target Co"},
+        "deal": {"type": "acquisition", "focus_areas": ["ip_ownership"]},
+        "data_room": {"path": str(tmp_path)},
+    }
+    path = tmp_path / "deal-config.json"
+    path.write_text(json.dumps(cfg))
+    return path
+
+
+class TestModelSelectionPlumbing:
+    @pytest.mark.asyncio
+    async def test_model_overrides_applied_to_effective_config_and_hash(self, tmp_path: Path) -> None:
+        from dd_agents.orchestrator.engine import PipelineEngine
+        from dd_agents.orchestrator.state import PipelineState
+        from dd_agents.persistence.provenance import compute_config_hash
+
+        cfg_path = _write_min_config(tmp_path)
+
+        # Baseline hash with no overrides.
+        engine0 = PipelineEngine(project_dir=tmp_path, deal_config_path=cfg_path)
+        state0 = await engine0._step_01_validate_config(PipelineState(project_dir=tmp_path))
+        base_hash = state0.config_hash
+
+        # With overrides plumbed through run_options.
+        engine = PipelineEngine(project_dir=tmp_path, deal_config_path=cfg_path)
+        engine._run_options = {
+            "model_profile": "economy",
+            "model_overrides": {"legal": "claude-haiku-4-5-20251001"},
+        }
+        state = await engine._step_01_validate_config(PipelineState(project_dir=tmp_path))
+
+        # Effective in-memory config carries the overrides.
+        assert state.deal_config["agent_models"]["profile"] == "economy"
+        assert state.deal_config["agent_models"]["overrides"]["legal"] == "claude-haiku-4-5-20251001"
+
+        # Provenance hash reflects the effective config (busts a stale checkpoint).
+        assert state.config_hash != base_hash
+        assert state.config_hash == compute_config_hash(state.deal_config)
+
+        # Typed config resolves the pinned model for the overridden agent.
+        typed = engine._typed_deal_config(state)
+        assert typed is not None
+        assert typed.agent_models.resolve_model("legal") == "claude-haiku-4-5-20251001"
+
+
+# ---------------------------------------------------------------------------
+# doctor command: pre-run provider verification
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorCommand:
+    def _invoke(self, monkeypatch: pytest.MonkeyPatch, env: dict[str, str], args: list[str]):
+        from click.testing import CliRunner
+
+        from dd_agents.cli import main
+
+        for key in (
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_AUTH_TOKEN",
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_VERTEX",
+            "AWS_PROFILE",
+            "AWS_ACCESS_KEY_ID",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        for k, v in env.items():
+            monkeypatch.setenv(k, v)
+        return CliRunner().invoke(main, ["doctor", *args])
+
+    def test_fails_without_credential(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        result = self._invoke(monkeypatch, {}, ["--json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["provider"] == "anthropic"
+        assert payload["credential_present"] is False
+
+    def test_passes_with_credential(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        result = self._invoke(monkeypatch, {"ANTHROPIC_API_KEY": "sk-ant-x"}, ["--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["credential_present"] is True
+
+    def test_gateway_routing_is_secret_free(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        result = self._invoke(
+            monkeypatch,
+            {
+                "ANTHROPIC_BASE_URL": "https://tok:secret@gw.example/v1",  # pragma: allowlist secret
+                "ANTHROPIC_AUTH_TOKEN": "sk-x",  # pragma: allowlist secret
+            },
+            ["--json"],
+        )
+        payload = json.loads(result.output)
+        assert payload["provider"] == "gateway"
+        assert payload["base_url"] == "https://gw.example/v1"
+        assert "secret" not in result.output

--- a/tests/unit/test_docs_drift.py
+++ b/tests/unit/test_docs_drift.py
@@ -267,3 +267,52 @@ def test_no_claude_agent_options_constructed_outside_the_seam() -> None:
         "ClaudeAgentOptions constructed outside dd_agents.llm.provider — route it "
         "through build_agent_options() instead:\n" + "\n".join(offenders)
     )
+
+
+# ---------------------------------------------------------------------------
+# Agnosticism documentation contract: env knobs + provider branches must exist
+# in code exactly as the model-providers doc names them (no silent doc drift).
+# ---------------------------------------------------------------------------
+
+
+def test_model_provider_env_vars_documented_match_code() -> None:
+    """Every ``DD_*`` model/provider knob in model-providers.md must exist in src/.
+
+    Catches a rename in code that silently desyncs the agnosticism docs (and
+    .env.example), the failure the docs-anti-drift standard exists to prevent.
+    """
+    doc = (REPO_ROOT / "docs" / "user-guide" / "model-providers.md").read_text(encoding="utf-8")
+    documented = set(re.findall(r"\bDD_[A-Z_]+\b", doc))
+    # Only assert the model/provider tuning knobs this guard owns.
+    owned = {v for v in documented if v.endswith("_MODEL") or v in {"DD_MODEL_PRICING", "DD_MAX_OUTPUT_TOKENS"}}
+    assert owned, "expected model-providers.md to document DD_* model knobs"
+
+    src_text = "\n".join(p.read_text(encoding="utf-8") for p in (REPO_ROOT / "src" / "dd_agents").rglob("*.py"))
+    missing = sorted(v for v in owned if v not in src_text)
+    assert not missing, (
+        f"model-providers.md documents DD_* env vars not present in src/ (renamed/removed in code?): {missing}"
+    )
+
+
+def test_provider_branches_match_resolve_provider() -> None:
+    """The providers named in model-providers.md must match resolve_provider()."""
+    # The four routing branches the seam can return.
+    import os
+    from unittest import mock
+
+    from dd_agents.llm.provider import resolve_provider
+
+    seen = set()
+    for env in (
+        {"ANTHROPIC_BASE_URL": "http://x"},
+        {"CLAUDE_CODE_USE_BEDROCK": "1"},
+        {"CLAUDE_CODE_USE_VERTEX": "1"},
+        {},
+    ):
+        with mock.patch.dict(os.environ, env, clear=True):
+            seen.add(resolve_provider().provider)
+    assert seen == {"gateway", "bedrock", "vertex", "anthropic"}
+
+    doc = (REPO_ROOT / "docs" / "user-guide" / "model-providers.md").read_text(encoding="utf-8").lower()
+    for provider in seen:
+        assert provider in doc, f"resolve_provider() returns {provider!r} but model-providers.md never mentions it"


### PR DESCRIPTION
## Why

PR #225 made the *reasoning seam* provider/model-agnostic. A 7-perspective adversarial audit (37 agents, every finding independently verified — 28 confirmed) then asked the harder question: is the **whole system** agnostic, easy to configure, and audit-provable? It wasn't, quite. This PR closes the gap.

## Highlights

**🔴 High — `--model-profile` / `--model-override` were silently dropped by `dd-agents run`.** The flags mutated an in-memory config the engine never received (it re-read the file from disk), and specialist/synthesis runners were constructed without any `deal_config`, so `get_model_id()` always returned `None`. A user who pinned `economy`/Haiku silently ran the default — a cost footgun. Now plumbed through `run_options`, applied to the effective config **before** hashing (so it rides provenance), and the typed config is fed into every runner via one cached helper. Cost is attributed to the real model instead of `""`.

**Reusable seams (KISS).** One `build_extraction_pipeline(config)` OCR seam replaces three divergent call sites (the search path was hardcoding GLM-OCR even when unavailable). Search cost routes through the shared pricing seam instead of duplicated constants.

**Enterprise auditability — provider/model is now *recorded*, not just logged.**
- `ProviderInfo.safe_base_url` strips credentials from `ANTHROPIC_BASE_URL` (the "secret-free" claim is now enforced, with a test feeding a credentialed URL).
- A secret-free routing receipt (provider, host-only base_url, distinct models used) lands in `metadata.json`, `cost_summary.json`, the HTML report's **Generation Provenance** section, and the Excel `_Metadata` sheet.
- Routing is folded into the **provenance hash**: resuming under a different provider/model is now rejected by the fail-closed gate (was silently allowed — could stitch two backends into one report).

**Config UX.** New **`dd-agents doctor [--probe] [--json]`** — pre-run provider/model verification + credential check + optional live query. **Live-validated against Bedrock** (`probe_ok: true`). GLM-OCR model tags are now env-overridable (matching the transcription path); new `glm-ocr-ollama` extra.

**Docs (zero-drift).** README now leads with the no-vendor-lock-in story (and fixes a missing `CLAUDE_CODE_USE_BEDROCK=1` in the Bedrock snippet); `model-providers.md` gains doctor / aux-path / auditability / provider-locked-resume sections; the gateway e2e is honestly described as opt-in (not CI-enforced); a new drift guard asserts the documented `DD_*_MODEL` knobs and provider branches exist in code.

## Audit

7 perspectives — completeness, config UX, compliance/auditability, dependencies, doc drift, positioning, parity/rigor — each finding adversarially re-verified against the code before action. Roadmap items the audit surfaced (per-agent provider routing, per-provider cost dashboard, model capability tiers, a CI gateway job) are captured for follow-up; this PR ships the verified defects + the high-leverage cheap wins.

## Gate

4273 unit + 67 integration pass; gateway e2e skips cleanly without creds; `mypy --strict` (221 files) + `ruff` + `ruff format` clean. **Zero new required dependencies** (the agno/litellm bits stay example-only; `glm-ocr-ollama` is opt-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)