### PR TITLE
fix(search): schema-safe column keys so structured search works on Bedrock/gateways

### DIFF
--- a/src/dd_agents/search/analyzer.py
+++ b/src/dd_agents/search/analyzer.py
@@ -21,9 +21,11 @@ backend (local/cloud parity), not only those that support json_schema.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os  # noqa: TCH003 - used at module level for env var reads
+import re
 from typing import TYPE_CHECKING, Any
 
 from dd_agents.agents.personas import DD_LEGAL_ANALYST
@@ -83,6 +85,25 @@ def _is_structured_output_error(exc: Exception) -> bool:
     """True if *exc* indicates the backend rejected ``output_format``."""
     msg = str(exc).lower()
     return any(marker in msg for marker in _STRUCTURED_OUTPUT_ERROR_MARKERS)
+
+
+# JSON-schema property keys must match this pattern on some providers (notably
+# Bedrock's tool-schema validator): ^[a-zA-Z0-9_.-]{1,64}$. User column names
+# are free text ("Governing Law"), so we map each to a schema-safe key for the
+# structured-output schema and translate back when parsing. Provider-agnostic:
+# the Anthropic API is lenient, but Bedrock/Vertex/gateways fronting them are
+# not — sanitizing keeps search working identically across all providers.
+def _schema_key(name: str) -> str:
+    """Map a free-text column name to a stable, schema-valid property key.
+
+    Deterministic and collision-resistant: a slug of the safe characters plus a
+    short hash of the original name, so two columns that slug identically still
+    get distinct keys, and the same name always yields the same key (stable
+    across runs/providers). Always matches ``^[a-zA-Z0-9_.-]{1,64}$``.
+    """
+    slug = re.sub(r"[^a-zA-Z0-9_.-]+", "_", name).strip("_")[:48]
+    digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+    return f"{slug}_{digest}" if slug else f"col_{digest}"
 
 
 def _looks_like_json(text: str) -> bool:
@@ -626,10 +647,13 @@ class SearchAnalyzer:
             "additionalProperties": False,
         }
 
+        # Key by schema-safe identifiers (not the raw, possibly-spaced column
+        # names) so providers that validate property-key patterns (Bedrock and
+        # gateways fronting it) accept the schema. Parsing maps keys back.
         return {
             "type": "object",
-            "properties": {name: column_schema for name in column_names},
-            "required": list(column_names),
+            "properties": {_schema_key(name): column_schema for name in column_names},
+            "required": [_schema_key(name) for name in column_names],
             "additionalProperties": False,
         }
 
@@ -781,9 +805,14 @@ class SearchAnalyzer:
         - Follow-up validation language ("pay special attention", "do not miss")
         - Targeted instructions that don't unduly inflate context
         """
-        column_descriptions = "\n".join(f"- **{col.name}**: {col.prompt}" for col in self._prompts.columns)
+        # Describe each column by its JSON key (schema-safe) AND its human label,
+        # so the model emits keys that match the structured-output schema across
+        # all providers (Bedrock rejects spaced keys).
+        column_descriptions = "\n".join(
+            f"- `{_schema_key(col.name)}` ({col.name}): {col.prompt}" for col in self._prompts.columns
+        )
 
-        column_names_list = ", ".join(f'"{col.name}"' for col in self._prompts.columns)
+        column_names_list = ", ".join(f'"{_schema_key(col.name)}"' for col in self._prompts.columns)
 
         return (
             DD_LEGAL_ANALYST + " reviewing subject contracts.\n\n"
@@ -1104,7 +1133,9 @@ class SearchAnalyzer:
 
         # Update only the conflicted columns with synthesis results.
         for col_name in conflicted_columns:
-            col_data = data.get(col_name)
+            col_data = data.get(_schema_key(col_name))
+            if col_data is None:
+                col_data = data.get(col_name)
             if not isinstance(col_data, dict):
                 continue
 
@@ -1197,7 +1228,9 @@ class SearchAnalyzer:
         # Uses parse_column_result to ensure answer normalization and
         # citation dedup are applied consistently.  Issue #24.
         for col_name in not_addressed:
-            col_data = data.get(col_name)
+            col_data = data.get(_schema_key(col_name))
+            if col_data is None:
+                col_data = data.get(col_name)
             if not isinstance(col_data, dict):
                 continue
             parsed = parse_column_result(col_data)
@@ -1295,7 +1328,11 @@ class SearchAnalyzer:
         incomplete_columns: list[str] = []
 
         for col in self._prompts.columns:
-            col_data = data.get(col.name)
+            # Prefer the schema-safe key; fall back to the raw name in case a
+            # prompt-JSON fallback response echoed the human label.
+            col_data = data.get(_schema_key(col.name))
+            if col_data is None:
+                col_data = data.get(col.name)
 
             if col_data is None:
                 # Column is completely missing from the response.

--- a/tests/unit/test_search_analyzer.py
+++ b/tests/unit/test_search_analyzer.py
@@ -2448,19 +2448,35 @@ class TestAnalysisSchema:
     """Tests for _build_analysis_schema and structured output integration."""
 
     def test_schema_has_all_columns(self) -> None:
-        """Schema must include every column name as a required top-level key."""
+        """Schema keys each column by its schema-SAFE id (cross-provider compat).
+
+        Provider-agnosticism: Bedrock (and gateways fronting it) reject JSON
+        property keys with spaces, so the schema must key by ``_schema_key``,
+        not the raw column name.
+        """
+        import re as _re
+
+        from dd_agents.search.analyzer import _schema_key
+
         columns = ["Consent Required", "Notice Required", "Governing Law"]
         schema = SearchAnalyzer._build_analysis_schema(columns)
 
+        expected_keys = {_schema_key(c) for c in columns}
         assert schema["type"] == "object"
-        assert set(schema["required"]) == set(columns)
-        assert set(schema["properties"].keys()) == set(columns)
+        assert set(schema["required"]) == expected_keys
+        assert set(schema["properties"].keys()) == expected_keys
         assert schema["additionalProperties"] is False
+        # Every key matches the Bedrock-accepted property-key pattern.
+        pat = _re.compile(r"^[a-zA-Z0-9_.-]{1,64}$")
+        for key in schema["properties"]:
+            assert pat.match(key), f"schema key {key!r} would be rejected by Bedrock"
 
     def test_column_schema_structure(self) -> None:
         """Each column must have answer, confidence (enum), and citations array."""
+        from dd_agents.search.analyzer import _schema_key
+
         schema = SearchAnalyzer._build_analysis_schema(["Test Column"])
-        col = schema["properties"]["Test Column"]
+        col = schema["properties"][_schema_key("Test Column")]
 
         assert col["type"] == "object"
         assert set(col["required"]) == {"answer", "confidence", "citations"}
@@ -2474,8 +2490,10 @@ class TestAnalysisSchema:
 
     def test_citation_schema_structure(self) -> None:
         """Citation objects must require all 4 fields with no extra properties."""
+        from dd_agents.search.analyzer import _schema_key
+
         schema = SearchAnalyzer._build_analysis_schema(["Col"])
-        citation = schema["properties"]["Col"]["properties"]["citations"]["items"]
+        citation = schema["properties"][_schema_key("Col")]["properties"]["citations"]["items"]
 
         assert citation["type"] == "object"
         assert set(citation["required"]) == {"file_path", "page", "section_ref", "exact_quote"}
@@ -2483,10 +2501,27 @@ class TestAnalysisSchema:
 
     def test_single_column_schema(self) -> None:
         """Schema works for a single column (Phase 3/4 with one conflict/gap)."""
+        from dd_agents.search.analyzer import _schema_key
+
         schema = SearchAnalyzer._build_analysis_schema(["Only Column"])
 
-        assert schema["required"] == ["Only Column"]
+        assert schema["required"] == [_schema_key("Only Column")]
         assert len(schema["properties"]) == 1
+
+    def test_schema_key_is_provider_safe_and_stable(self) -> None:
+        """_schema_key yields Bedrock-valid keys, stable + collision-resistant."""
+        import re as _re
+
+        from dd_agents.search.analyzer import _schema_key
+
+        pat = _re.compile(r"^[a-zA-Z0-9_.-]{1,64}$")
+        for name in ["Governing Law", "Change of Control?", "IP / Ownership", "x" * 200, "日本語", "!!!"]:
+            key = _schema_key(name)
+            assert pat.match(key), f"{key!r} would be rejected by Bedrock"
+        # Stable across calls.
+        assert _schema_key("Governing Law") == _schema_key("Governing Law")
+        # Distinct names that slugify identically still get distinct keys.
+        assert _schema_key("A B") != _schema_key("A  B")
 
     def test_schema_is_valid_json_schema(self) -> None:
         """Schema can be serialized to JSON (required by SDK)."""
@@ -2534,12 +2569,14 @@ class TestStructuredOutputWiring:
         with patch.object(analyzer, "_call_claude", side_effect=mock_call):
             await analyzer.analyze_all([subject])
 
-        # Phase 1 should have passed a schema.
+        # Phase 1 should have passed a schema, keyed by schema-safe ids.
+        from dd_agents.search.analyzer import _schema_key
+
         assert len(captured_schemas) >= 1
         schema = captured_schemas[0]
         assert schema is not None
-        assert "Consent Required" in schema["required"]
-        assert "Notice Required" in schema["required"]
+        assert _schema_key("Consent Required") in schema["required"]
+        assert _schema_key("Notice Required") in schema["required"]
 
     @pytest.mark.asyncio
     async def test_phase3_passes_conflicted_schema(self, tmp_path: Path) -> None:
@@ -2577,12 +2614,14 @@ class TestStructuredOutputWiring:
         with patch.object(analyzer, "_call_claude", side_effect=mock_call):
             await analyzer._synthesis_pass(merged, chunk_results, ["Consent Required"], subject)
 
+        from dd_agents.search.analyzer import _schema_key
+
         assert len(captured_schemas) == 1
         schema = captured_schemas[0]
         assert schema is not None
-        # Only conflicted column in schema.
-        assert schema["required"] == ["Consent Required"]
-        assert "Notice Required" not in schema["properties"]
+        # Only conflicted column in schema (keyed by schema-safe id).
+        assert schema["required"] == [_schema_key("Consent Required")]
+        assert _schema_key("Notice Required") not in schema["properties"]
 
     @pytest.mark.asyncio
     async def test_phase4_passes_not_addressed_schema(self, tmp_path: Path) -> None:
@@ -2607,12 +2646,14 @@ class TestStructuredOutputWiring:
         with patch.object(analyzer, "_call_claude", side_effect=mock_call):
             await analyzer._validation_pass(result, file_texts, subject)
 
+        from dd_agents.search.analyzer import _schema_key
+
         assert len(captured_schemas) == 1
         schema = captured_schemas[0]
         assert schema is not None
-        # Only NOT_ADDRESSED column in schema.
-        assert schema["required"] == ["Notice Required"]
-        assert "Consent Required" not in schema["properties"]
+        # Only NOT_ADDRESSED column in schema (keyed by schema-safe id).
+        assert schema["required"] == [_schema_key("Notice Required")]
+        assert _schema_key("Consent Required") not in schema["properties"]
 
     @pytest.mark.asyncio
     async def test_system_prompt_no_output_format_boilerplate(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Answering *"is **every** flow actually provider-agnostic?"* I drove the full `search` flow **live through a LiteLLM gateway → Bedrock** — and it broke: every subject came back `incomplete — missing column`. Root cause: search used **raw column names** (e.g. `"Governing Law"`) as JSON-schema property keys. The Anthropic API accepts that; **Bedrock's tool-schema validator rejects** anything outside `^[a-zA-Z0-9_.-]{1,64}$`, so multi-word columns 400'd on Bedrock and on any gateway fronting it.

This was a genuine provider-agnosticism gap (not a gateway artifact) — the same search was not equally usable across providers — and it had been latent because CI only exercises the lenient Anthropic path.

## Fix

A deterministic, collision-resistant `_schema_key(name)` (slug + short SHA suffix) maps each column to a schema-valid key, used consistently at:
- schema build (`_build_analysis_schema`)
- the system-prompt key list
- all three parse sites (phase 1 map, phase 3 synthesis, phase 4 validation), with a raw-name fallback so the prompt-JSON fallback path still parses.

Internal result dicts stay keyed by the human column name → reports/Excel output unchanged.

## Live verification (post-fix, same gateway → Bedrock)

`Failures: 0` (was 3), `Citations verified: 1`, and **zero new schema-pattern rejections** in the proxy log. The only remaining backend 400s are a benign "adaptive thinking not supported" capability probe that retries to 200.

## Gate

Search suites pass (142 analyzer + CLI + agnosticism); `mypy --strict` + `ruff` + `ruff format` clean. Zero new dependencies. Tests updated to assert the schema-safe-key contract + a Bedrock-pattern check, plus a new `_schema_key` safety/stability/collision test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)