### PR TITLE
chore(release): bump version to 1.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dd-agents"
-version = "1.11.0"
+version = "1.12.0"
 description = "Open-source forensic M&A due diligence — 13 AI agents read your data room across 9 domains, cross-reference findings no single reviewer connects, and cite every one to an exact quote"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Release v1.12.0

Releases the model/provider-agnosticism epic + accumulated fixes since v1.11.0.

### Highlights
- **feat(llm)**: one provider/model-agnostic seam across all LLM call sites (#225)
- **feat(llm)**: `dd-agents doctor` command + per-run provider/model audit receipt; end-to-end agnosticism + provider-locked resume (#226)
- **fix(search)**: schema-safe column keys so structured search works on AWS Bedrock and gateways (#227) — *search was returning errors on Bedrock before this*
- **fix(search)**: robust structured-output fallback across providers + durable model attribution in cost/audit artifacts (#228)
- examples (agno-bindu provider-agnostic) + honest provider docs (#223, #224); full docs audit (#229)

### Verification
- Cross-provider **verified live**: full 38-step run end-to-end through a gateway on both Claude and a non-Claude model (DeepSeek v3.2).
- Gate: **4278 unit + 67 integration pass**; `mypy --strict` + `ruff` + `format` clean; sdist + wheel build clean; CLI smoke (18 commands) OK.

Single-line change (`pyproject.toml` version) — tagging `v1.12.0` after merge triggers the release workflow (PyPI, Docker GHCR + Hub, Homebrew, GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)