### PR TITLE
v1.15.0 — completeness/integrity in reports + per-provider cost audit (#238, #240, #242)

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -57,7 +57,7 @@ Output appears in your data room at `_dd/forensic-dd/runs/latest/report/`.
 ## Output
 
 - **Interactive HTML report** — Go/No-Go verdict, executive narrative, severity filtering, cross-domain synthesis
-- **14-sheet Excel report** — structured findings for downstream modeling
+- **16-sheet Excel report** — structured findings for downstream modeling
 - **Per-subject JSON** — every finding with severity, citations, and cross-references
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ dd-agents run deal-config.json
 Analyzes every document through 9 domain lenses, cross-references findings, and validates quality through 5 blocking gates. Produces:
 
 - **Interactive HTML report** — Go/No-Go verdict with executive narrative, progressive disclosure (decision → actions → domain details → full evidence), severity filtering
-- **14-sheet Excel report** — structured findings, cross-references, audit trail for downstream modeling
+- **16-sheet Excel report** — structured findings, cross-references, audit trail for downstream modeling
 - **Per-subject JSON findings** — every finding with severity, citations, cross-references, and governance graph edges
 
 ### Quick Scan — Red Flag Triage in Minutes
@@ -370,7 +370,7 @@ _dd/forensic-dd/
         merged/                   # Deduplicated cross-domain findings
       report/
         dd_report.html            # Interactive HTML report
-        dd_report.xlsx            # 14-sheet Excel report
+        dd_report.xlsx            # 16-sheet Excel report
       audit.json                  # 31 quality validation checks
       numerical_manifest.json     # Every financial figure traced to source
       metadata.json               # Run metadata and API costs

--- a/config/deal-config.template.json
+++ b/config/deal-config.template.json
@@ -116,6 +116,22 @@
       "enabled": true
     }
   },
+  "agent_models": {
+    "profile": "standard",
+    "overrides": {},
+    "routes": {},
+    "budget_limit_usd": null,
+    "_routes_example": {
+      "_note": "Per-agent provider/model routing. Move an entry into 'routes' (keyed by agent name) to activate it. Token VALUE is never stored here — give the env-var NAME in 'auth_token_env'; its value is read at run time. base_url must not embed credentials.",
+      "red_flag_scanner": {
+        "model": "claude-haiku-4-5-20251001"
+      },
+      "judge": {
+        "base_url": "https://EXAMPLE_GATEWAY_HOST/v1",
+        "auth_token_env": "MY_GATEWAY_TOKEN"
+      }
+    }
+  },
   "extraction": {
     "ocr_backend": "auto"
   },

--- a/config/report_schema.json
+++ b/config/report_schema.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "description": "14-sheet Excel report schema for forensic M&A due diligence. Loaded by build_report.py at runtime -- never hardcode sheet definitions.",
+  "description": "Excel report schema for forensic M&A due diligence. Loaded by build_report.py at runtime -- never hardcode sheet definitions.",
   "global_formatting": {
     "header_bold": true,
     "header_bg_color": "#4472C4",
@@ -463,6 +463,49 @@
         "bottom": [
           { "column": "change_type", "formula": "COUNTA(change_type)" },
           { "column": "subject", "formula": "COUNTA_UNIQUE(subject)" }
+        ]
+      }
+    },
+    {
+      "name": "Request_List_Completeness",
+      "required": false,
+      "activation_condition": "always",
+      "description": "Requested-document reconciliation: received vs. missing-required vs. missing-optional (Issue #192/#238).",
+      "source": "inventory/request_list.json",
+      "_source_note": "One row per status bucket; empty when no request_list configured.",
+      "row_rule": "one_row_per_status_bucket",
+      "columns": [
+        { "name": "Status", "key": "status", "type": "string", "width": 24 },
+        { "name": "Count", "key": "count", "type": "integer", "width": 10 },
+        { "name": "Items", "key": "items", "type": "string", "width": 70 }
+      ],
+      "sort_order": [],
+      "conditional_formatting": [],
+      "summary_formulas": {}
+    },
+    {
+      "name": "Model_Integrity",
+      "required": false,
+      "activation_condition": "always",
+      "description": "Spreadsheet formula-integrity issues citing exact cells: hardcoded overrides, circular refs, #REF!, broken links (Issue #194/#238).",
+      "source": "inventory/formula_audit.json",
+      "_source_note": "One row per detected issue; empty when no spreadsheet formulas.",
+      "row_rule": "one_row_per_issue",
+      "columns": [
+        { "name": "File", "key": "file", "type": "string", "width": 40 },
+        { "name": "Sheet", "key": "sheet", "type": "string", "width": 18 },
+        { "name": "Cell", "key": "cell", "type": "string", "width": 10 },
+        { "name": "Issue Type", "key": "kind", "type": "string", "width": 22 },
+        { "name": "Detail", "key": "detail", "type": "string", "width": 60 }
+      ],
+      "sort_order": [
+        { "column": "file", "direction": "asc" }
+      ],
+      "conditional_formatting": [],
+      "summary_formulas": {
+        "bottom": [
+          { "column": "file", "value": "TOTAL" },
+          { "column": "kind", "formula": "COUNTA(kind)" }
         ]
       }
     },

--- a/config/report_schema.json
+++ b/config/report_schema.json
@@ -502,12 +502,7 @@
         { "column": "file", "direction": "asc" }
       ],
       "conditional_formatting": [],
-      "summary_formulas": {
-        "bottom": [
-          { "column": "file", "value": "TOTAL" },
-          { "column": "kind", "formula": "COUNTA(kind)" }
-        ]
-      }
+      "summary_formulas": {}
     },
     {
       "name": "_Metadata",

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -76,7 +76,7 @@
       "Cross-domain cross-referencing connects findings no single reviewer links",
       "Every finding traced to an exact page, section, and verbatim quote",
       "Anti-fabrication quality gate halts rather than ship unverified output",
-      "Interactive HTML report with Go/No-Go view + 14-sheet Excel export",
+      "Interactive HTML report with Go/No-Go view + 16-sheet Excel export",
       "Runs locally; open-source (Apache-2.0); pip install or Docker"
     ]
   }

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -391,6 +391,7 @@ dd-agents chat [OPTIONS]
 | `--max-turns` | Int | 200 | Max tool-use turns per question (max: 500) |
 | `--no-limit` | Flag | Off | Remove per-turn caps for complex tasks (session cost is the only brake) |
 | `--no-tools` | Flag | Off | Disable document tools (findings-only mode) |
+| `--question / -q` | String | — | Ask a single question non-interactively and exit (scriptable; no TTY needed) |
 | `--verbose / -v` | Flag | Off | Enable verbose logging |
 
 Chat mode provides MCP document tools (citation verification, page reading, entity resolution), persistent memory, and document export. The model can save key insights during conversation, recall them in future sessions, and generate Excel workbooks, Word documents, and CSV files on request using the `run_export_script` tool. Exported files are saved to `_dd/exports/`.
@@ -417,6 +418,9 @@ dd-agents chat --no-limit --max-cost 25.0
 
 # Higher budget with specific model
 dd-agents chat --max-cost 20.0 --model claude-sonnet-4-6
+
+# Single question, non-interactively (scriptable — prints the answer and exits)
+dd-agents chat -q "What are the top 3 P0 findings and their citations?"
 ```
 
 ---

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -187,7 +187,7 @@ See [Running the Pipeline](running-pipeline.md) for all options including resume
 After the pipeline completes, find the outputs in `_dd/forensic-dd/runs/latest/report/`:
 
 - `dd_report.html` -- Interactive HTML report with cross-domain findings, severity filtering, and drill-down to exact clauses
-- `dd_report.xlsx` -- 14-sheet Excel report for detailed analysis and downstream work
+- `dd_report.xlsx` -- 16-sheet Excel report for detailed analysis and downstream work
 
 Open `dd_report.html` in a browser. See [Reading the Report](reading-report.md) for a walkthrough of each section.
 

--- a/docs/user-guide/reading-report.md
+++ b/docs/user-guide/reading-report.md
@@ -1,6 +1,6 @@
 # Reading the Report
 
-The pipeline produces two report formats: an interactive HTML report for navigation and drill-down, and a 14-sheet Excel report for detailed analysis. Both include sourced citations, severity classifications, and cross-domain correlation. These reports provide deep, granular analysis across 9 specialist domains — structured output your team uses as the basis for their own deliverables (board presentations, advisor memos, negotiation checklists, integration plans).
+The pipeline produces two report formats: an interactive HTML report for navigation and drill-down, and a 16-sheet Excel report for detailed analysis. Both include sourced citations, severity classifications, and cross-domain correlation. These reports provide deep, granular analysis across 9 specialist domains — structured output your team uses as the basis for their own deliverables (board presentations, advisor memos, negotiation checklists, integration plans).
 
 **This tool does not replace professional advisors.** Use the structured findings alongside your advisory process to search, correlate, and track risks more efficiently.
 
@@ -103,7 +103,7 @@ dd-agents export-pdf _dd/forensic-dd/runs/latest/report/dd_report.html
 
 ## Excel Report
 
-The Excel report at `dd_report.xlsx` contains 14 sheets:
+The Excel report at `dd_report.xlsx` contains 16 sheets:
 
 | Sheet | Content |
 |-------|---------|
@@ -120,9 +120,30 @@ The Excel report at `dd_report.xlsx` contains 14 sheets:
 | Entity_Resolution_Log | Entity matching decisions and confidence scores |
 | Quality_Audit | QA validation results and audit trail |
 | Run_Diff | Changes from prior run (incremental mode only) |
+| Request_List_Completeness | Requested-document reconciliation: received vs. missing-required vs. missing-optional (when a `request_list` is configured) |
+| Model_Integrity | Spreadsheet formula-integrity issues citing exact cells (hardcoded overrides, circular refs, `#REF!`, broken external links) |
 | _Metadata | Run configuration, timing, costs, versions |
 
 Sheets use conditional formatting: red for P0/P1, yellow for P2, no fill for P3.
+
+The HTML report's **Data-Room Completeness & Model Integrity** section surfaces
+the same request-list and formula-integrity views for browser-based review.
+
+## Generation Provenance & Cost
+
+The HTML report's **Methodology** section records which provider and model(s)
+produced the analysis, plus an estimated cost breakdown — by model, and (for a
+mixed-provider run) by provider and per agent. This is the audit trail for
+governance review; the same routing receipt is persisted in `metadata.json` and
+`cost_summary.json`.
+
+Costs are estimates. A model with a known rate (Claude models, or any model you
+price via the `DD_MODEL_PRICING` env override) is costed exactly; any other
+model — e.g. one reached through an Anthropic-compatible gateway — is costed at a
+default rate and labelled **(estimated)** so gateway/non-Claude spend is never
+read as exact. To make those exact, supply rates via `DD_MODEL_PRICING`. See
+[Model Providers](model-providers.md) for provider/model selection and per-agent
+routing.
 
 ## Next Steps
 

--- a/docs/user-guide/running-pipeline.md
+++ b/docs/user-guide/running-pipeline.md
@@ -192,7 +192,7 @@ _dd/forensic-dd/
         │   └── merged/            # Deduplicated merged findings
         ├── report/
         │   ├── dd_report.html     # Interactive HTML report
-        │   └── dd_report.xlsx     # 14-sheet Excel report
+        │   └── dd_report.xlsx     # 16-sheet Excel report
         ├── pre_merge_validation.json  # Cross-agent validation report
         ├── audit.json             # QA validation results
         ├── metadata.json          # Run metadata and costs

--- a/examples/project-atlas/README.md
+++ b/examples/project-atlas/README.md
@@ -16,7 +16,7 @@ so the pipeline's headline capability — **cross-domain cross-referencing** —
 ## What you'll build
 
 Running the pipeline produces a `_dd/` output directory containing extracted findings, entity
-graphs, a cross-domain HTML report (with a Go/No-Go view), and a 14-sheet Excel companion.
+graphs, a cross-domain HTML report (with a Go/No-Go view), and a 16-sheet Excel companion.
 
 The pipeline will:
 1. Discover and inventory every document in the data room.
@@ -24,7 +24,7 @@ The pipeline will:
 3. Resolve entity names across documents.
 4. Run the specialist agents (Legal, Finance, Commercial, ProductTech, Cybersecurity, HR, Tax, Regulatory, ESG).
 5. Cross-reference findings across domains (the Legal→Finance change-of-control link is the hero).
-6. Produce the HTML report + 14-sheet Excel companion.
+6. Produce the HTML report + 16-sheet Excel companion.
 
 ## Prerequisites
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dd-agents"
-version = "1.14.0"
+version = "1.15.0"
 description = "Open-source forensic M&A due diligence — 13 AI agents read your data room across 9 domains, cross-reference findings no single reviewer connects, and cite every one to an exact quote"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dd_agents/agents/base.py
+++ b/src/dd_agents/agents/base.py
@@ -152,6 +152,26 @@ class BaseAgentRunner(ABC):
                 env["ANTHROPIC_AUTH_TOKEN"] = token
         return env
 
+    def get_route_provider(self) -> tuple[str | None, str | None]:
+        """Return ``(provider, safe_base_url)`` for this agent's call (Issue #240).
+
+        Cost/audit attribution counterpart to :meth:`get_route_env`. When the
+        agent has a per-agent gateway route, the provider is ``"gateway"`` and
+        the base_url is the credential-stripped host. Otherwise ``(None, None)``
+        — the run-wide provider (``resolve_provider()``) covers it. Secret-free
+        and read-only; never touches process env.
+        """
+        if self.deal_config is None:
+            return (None, None)
+        agent_models = getattr(self.deal_config, "agent_models", None)
+        if agent_models is None or not hasattr(agent_models, "resolve_route"):
+            return (None, None)
+        route = agent_models.resolve_route(self.get_agent_name())
+        if route is None or not getattr(route, "base_url", None):
+            return (None, None)
+        # A per-agent base_url is, by definition, an Anthropic-compatible gateway.
+        return ("gateway", getattr(route, "safe_base_url", None))
+
     @abstractmethod
     def get_system_prompt(self) -> str:
         """Return the system-level preamble injected before the user prompt."""
@@ -229,6 +249,11 @@ class BaseAgentRunner(ABC):
             # the model that produced them. See CostTracker.record(model=...).
             "model": self.get_model_id() or "",
         }
+        # Per-agent provider attribution for the cost/audit receipt (Issue #240).
+        # Both None when the agent rides the run-wide default route. Secret-free.
+        route_provider, route_base_url = self.get_route_provider()
+        result["provider"] = route_provider
+        result["base_url"] = route_base_url
 
         start = time.monotonic()
         try:

--- a/src/dd_agents/agents/cost_tracker.py
+++ b/src/dd_agents/agents/cost_tracker.py
@@ -183,6 +183,14 @@ class AgentCostEntry(BaseModel):
     output_tokens: int = Field(default=0, description="Number of output tokens produced")
     model: str = Field(default="", description="Model ID used for this invocation")
     cost_usd: float = Field(default=0.0, description="Estimated cost in USD")
+    # Per-agent routing attribution (Issue #240): which provider/gateway answered
+    # this call. None when the agent rode the run-wide default (no per-agent
+    # route) — rolled up under the run's provider. base_url is secret-free
+    # (host-only, credentials stripped) so the cost artifact is safe to persist.
+    provider: str | None = Field(
+        default=None, description="LLM provider for this call: anthropic|bedrock|vertex|gateway"
+    )
+    base_url: str | None = Field(default=None, description="Gateway base URL (host only, credentials stripped), if any")
 
     @property
     def total_tokens(self) -> int:
@@ -221,8 +229,17 @@ class CostTracker:
         input_tokens: int,
         output_tokens: int,
         model: str,
+        provider: str | None = None,
+        base_url: str | None = None,
     ) -> AgentCostEntry:
-        """Record a usage entry and return it.  Thread-safe."""
+        """Record a usage entry and return it.  Thread-safe.
+
+        ``provider``/``base_url`` attribute the call to the LLM endpoint that
+        answered it (Issue #240). They are None for an agent on the run-wide
+        default route; a per-agent gateway route supplies both. ``base_url`` must
+        already be secret-free (host-only) — callers pass the route's
+        ``safe_base_url`` / the resolved provider receipt, never a raw URL.
+        """
         cost = _estimate_cost(model, input_tokens, output_tokens)
         entry = AgentCostEntry(
             agent_name=agent_name,
@@ -231,6 +248,8 @@ class CostTracker:
             output_tokens=output_tokens,
             model=model,
             cost_usd=cost,
+            provider=provider,
+            base_url=base_url,
         )
         with self._lock:
             self.entries.append(entry)
@@ -288,6 +307,38 @@ class CostTracker:
             bucket["estimated"] = bucket["estimated"] or _is_estimated_pricing(e.model)
         return {k: {**v, "cost": round(v["cost"], 4)} for k, v in agg.items()}
 
+    def cost_by_provider(self) -> dict[str, dict[str, Any]]:
+        """Return per-provider cost rollup for mixed-provider runs (Issue #240).
+
+        Maps provider id → ``{cost, input_tokens, output_tokens, base_url}``.
+        Entries with no per-agent provider attribution (the run-wide default
+        route) are keyed as ``"(run default)"`` so a single-provider run rolls up
+        under one bucket. ``base_url`` is the (secret-free) gateway host when the
+        bucket is a single gateway, else None. Empty when no entries recorded.
+        """
+        agg: dict[str, dict[str, Any]] = {}
+        for e in self.entries:
+            key = e.provider or "(run default)"
+            bucket = agg.setdefault(
+                key,
+                {"cost": 0.0, "input_tokens": 0, "output_tokens": 0, "base_urls": set()},
+            )
+            bucket["cost"] += e.cost_usd
+            bucket["input_tokens"] += e.input_tokens
+            bucket["output_tokens"] += e.output_tokens
+            if e.base_url:
+                bucket["base_urls"].add(e.base_url)
+        result: dict[str, dict[str, Any]] = {}
+        for key, v in agg.items():
+            urls: set[str] = v.pop("base_urls")
+            result[key] = {
+                **v,
+                "cost": round(v["cost"], 4),
+                # One host → report it; multiple (or none) → None to stay unambiguous.
+                "base_url": next(iter(urls)) if len(urls) == 1 else None,
+            }
+        return result
+
     def is_budget_exceeded(self) -> bool:
         """Return True if total cost exceeds the budget limit."""
         if self.budget_limit_usd is None:
@@ -318,5 +369,8 @@ class CostTracker:
             "by_agent": {k: round(v, 4) for k, v in self.cost_by_agent().items()},
             "by_step": {k: round(v, 4) for k, v in self.cost_by_step().items()},
             "by_model": self.cost_by_model(),
+            # Per-provider rollup for mixed-provider runs (Issue #240). A
+            # single-provider run rolls up under one "(run default)" bucket.
+            "by_provider": self.cost_by_provider(),
             "entries": [e.model_dump() for e in self.entries],
         }

--- a/src/dd_agents/config/report_schema.json
+++ b/src/dd_agents/config/report_schema.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "description": "14-sheet Excel report schema for forensic M&A due diligence. Loaded by build_report.py at runtime -- never hardcode sheet definitions.",
+  "description": "Excel report schema for forensic M&A due diligence. Loaded by build_report.py at runtime -- never hardcode sheet definitions.",
   "global_formatting": {
     "header_bold": true,
     "header_bg_color": "#4472C4",
@@ -463,6 +463,49 @@
         "bottom": [
           { "column": "change_type", "formula": "COUNTA(change_type)" },
           { "column": "subject", "formula": "COUNTA_UNIQUE(subject)" }
+        ]
+      }
+    },
+    {
+      "name": "Request_List_Completeness",
+      "required": false,
+      "activation_condition": "always",
+      "description": "Requested-document reconciliation: received vs. missing-required vs. missing-optional (Issue #192/#238).",
+      "source": "inventory/request_list.json",
+      "_source_note": "One row per status bucket; empty when no request_list configured.",
+      "row_rule": "one_row_per_status_bucket",
+      "columns": [
+        { "name": "Status", "key": "status", "type": "string", "width": 24 },
+        { "name": "Count", "key": "count", "type": "integer", "width": 10 },
+        { "name": "Items", "key": "items", "type": "string", "width": 70 }
+      ],
+      "sort_order": [],
+      "conditional_formatting": [],
+      "summary_formulas": {}
+    },
+    {
+      "name": "Model_Integrity",
+      "required": false,
+      "activation_condition": "always",
+      "description": "Spreadsheet formula-integrity issues citing exact cells: hardcoded overrides, circular refs, #REF!, broken links (Issue #194/#238).",
+      "source": "inventory/formula_audit.json",
+      "_source_note": "One row per detected issue; empty when no spreadsheet formulas.",
+      "row_rule": "one_row_per_issue",
+      "columns": [
+        { "name": "File", "key": "file", "type": "string", "width": 40 },
+        { "name": "Sheet", "key": "sheet", "type": "string", "width": 18 },
+        { "name": "Cell", "key": "cell", "type": "string", "width": 10 },
+        { "name": "Issue Type", "key": "kind", "type": "string", "width": 22 },
+        { "name": "Detail", "key": "detail", "type": "string", "width": 60 }
+      ],
+      "sort_order": [
+        { "column": "file", "direction": "asc" }
+      ],
+      "conditional_formatting": [],
+      "summary_formulas": {
+        "bottom": [
+          { "column": "file", "value": "TOTAL" },
+          { "column": "kind", "formula": "COUNTA(kind)" }
         ]
       }
     },

--- a/src/dd_agents/config/report_schema.json
+++ b/src/dd_agents/config/report_schema.json
@@ -502,12 +502,7 @@
         { "column": "file", "direction": "asc" }
       ],
       "conditional_formatting": [],
-      "summary_formulas": {
-        "bottom": [
-          { "column": "file", "value": "TOTAL" },
-          { "column": "kind", "formula": "COUNTA(kind)" }
-        ]
-      }
+      "summary_formulas": {}
     },
     {
       "name": "_Metadata",

--- a/src/dd_agents/extraction/formula_audit.py
+++ b/src/dd_agents/extraction/formula_audit.py
@@ -25,10 +25,23 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+class FormulaAuditReport(TypedDict):
+    """Serializable data-room formula-audit report (Issue #238)."""
+
+    files_scanned: int
+    files_with_formulas: int
+    files_with_issues: int
+    total_issues: int
+    by_kind: dict[str, int]
+    issues: list[dict[str, str]]
+    truncated: bool
+
 
 # A formula map: sheet name -> {cell coordinate (e.g. "B7") -> formula text incl. leading "="}.
 FormulaMap = dict[str, dict[str, str]]
@@ -232,6 +245,68 @@ def audit_formulas(formula_map: FormulaMap) -> list[FormulaIssue]:
 
     issues.sort(key=lambda i: (i.sheet, _sort_key(i.cell)))
     return issues
+
+
+def audit_data_room(
+    paths: list[Path],
+    *,
+    max_files: int = 200,
+    max_issues: int = 500,
+) -> FormulaAuditReport:
+    """Audit every ``.xlsx`` in *paths* and return a serializable report (Issue #238).
+
+    Reuses the pure per-workbook detector (:func:`extract_formula_map` +
+    :func:`audit_formulas`) so the report and the agent prompt share one audit.
+    The result is JSON-safe (persisted to ``formula_audit.json`` and surfaced in
+    the HTML/Excel report). Best-effort and parity-safe: a data room with no
+    spreadsheet formulas yields ``files_with_formulas == 0`` and an empty
+    ``issues`` list, so nothing renders. Bounded by *max_files* / *max_issues*;
+    any overflow is reported in ``truncated`` so silence never masks a cap.
+
+    Each issue row carries ``file`` (the path as given), ``sheet``, ``cell``,
+    ``kind``, and ``detail`` — enough to cite ``file → Sheet!Cell`` in the report.
+    """
+    xlsx = [p for p in paths if p.suffix.lower() == ".xlsx"]
+    files_truncated = len(xlsx) > max_files
+    xlsx = xlsx[:max_files]
+
+    issue_rows: list[dict[str, str]] = []
+    by_kind: dict[str, int] = defaultdict(int)
+    files_with_formulas = 0
+    files_with_issues = 0
+
+    for path in xlsx:
+        formula_map = extract_formula_map(path)
+        if not formula_map:
+            continue
+        files_with_formulas += 1
+        issues = audit_formulas(formula_map)
+        if issues:
+            files_with_issues += 1
+        for issue in issues:
+            issue_rows.append(
+                {
+                    "file": str(path),
+                    "sheet": issue.sheet,
+                    "cell": issue.cell,
+                    "kind": issue.kind,
+                    "detail": issue.detail,
+                }
+            )
+            by_kind[issue.kind] += 1
+
+    issues_truncated = len(issue_rows) > max_issues
+    issue_rows = issue_rows[:max_issues]
+
+    return FormulaAuditReport(
+        files_scanned=len(xlsx),
+        files_with_formulas=files_with_formulas,
+        files_with_issues=files_with_issues,
+        total_issues=sum(by_kind.values()),
+        by_kind=dict(sorted(by_kind.items())),
+        issues=issue_rows,
+        truncated=files_truncated or issues_truncated,
+    )
 
 
 def format_formula_audit(formula_map: FormulaMap, issues: list[FormulaIssue], *, max_issues: int = 40) -> str:

--- a/src/dd_agents/models/config.py
+++ b/src/dd_agents/models/config.py
@@ -479,6 +479,27 @@ class AgentModelsConfig(BaseModel):
         """
         return self.routes.get(agent_name)
 
+    def routing_receipt(self) -> dict[str, dict[str, str]]:
+        """Return a secret-free per-agent routing receipt (Issue #240).
+
+        Maps agent name → ``{model?, base_url?}`` for every agent with a
+        configured route, using the credential-stripped ``safe_base_url`` (the
+        auth-token env-var name is intentionally omitted — it's neither a secret
+        nor useful in an audit trail). Empty when no routes are configured, so a
+        single-provider run records an empty map. Persisted into RunMetadata.
+        """
+        receipt: dict[str, dict[str, str]] = {}
+        for agent_name, route in self.routes.items():
+            entry: dict[str, str] = {}
+            if route.model:
+                entry["model"] = route.model
+            safe = route.safe_base_url
+            if safe:
+                entry["base_url"] = safe
+            if entry:
+                receipt[agent_name] = entry
+        return receipt
+
 
 class PrecedenceConfig(BaseModel):
     """Document precedence configuration (Issue #163).

--- a/src/dd_agents/models/persistence.py
+++ b/src/dd_agents/models/persistence.py
@@ -34,6 +34,14 @@ class RunMetadata(BaseModel):
         default=None, description="Gateway base URL (host only, credentials stripped), if any"
     )
     llm_models: list[str] = Field(default_factory=list, description="Distinct model ids actually used across the run")
+    # Per-agent provider/model routing receipt (Issue #240): which agents ran on
+    # a non-default route, for mixed-provider audit. Maps agent name → secret-free
+    # {model?, base_url?} (base_url is host-only; credentials never persisted).
+    # Empty when no per-agent routes were configured (single-provider run).
+    per_agent_routes: dict[str, dict[str, str]] = Field(
+        default_factory=dict,
+        description="Per-agent routing receipt: agent name → {model, base_url} (secret-free). Empty for default runs.",
+    )
     cross_skill_run_ids: dict[str, str] = Field(
         default_factory=dict, description="Map of skill name to run_id for cross-skill data"
     )

--- a/src/dd_agents/orchestrator/engine.py
+++ b/src/dd_agents/orchestrator/engine.py
@@ -1024,6 +1024,12 @@ class PipelineEngine:
         # completeness view to the inventory tier. Absent config = no-op.
         self._reconcile_request_list(state, files, inv_dir)
 
+        # --- Formula-integrity audit of spreadsheets (Issue #194/#238) ---
+        # Deterministic model-integrity audit across every .xlsx, persisted so
+        # the report surfaces it independently of whether the Finance agent also
+        # flagged it. Parity-safe: a room with no formulas writes nothing.
+        self._audit_spreadsheet_formulas(state, files, inv_dir)
+
         logger.info(
             "Inventory: %d subjects, %d reference files",
             state.total_subjects,
@@ -1044,6 +1050,51 @@ class PipelineEngine:
             ov = prec.get("vdr_overrides")
             if isinstance(ov, dict):
                 return {str(k): str(v) for k, v in ov.items()}
+        return {}
+
+    def _audit_spreadsheet_formulas(self, state: PipelineState, files: list[Any], inv_dir: Path) -> None:
+        """Audit every .xlsx for model-integrity issues and persist (Issue #238).
+
+        Writes ``inventory/formula_audit.json`` (serializable; loaded into the
+        report's run_metadata) when any spreadsheet contains formulas. Best-effort
+        and parity-safe: any failure (or a room with no .xlsx formulas) leaves the
+        run unchanged and writes nothing.
+        """
+        try:
+            from dd_agents.extraction.formula_audit import audit_data_room
+
+            xlsx_paths = [state.project_dir / f.path for f in files if str(f.path).lower().endswith(".xlsx")]
+            if not xlsx_paths:
+                return
+            report = audit_data_room(xlsx_paths)
+            if not report["files_with_formulas"]:
+                return
+            # Re-root issue file paths to data-room-relative (no local-path leak).
+            base = str(state.project_dir).rstrip("/") + "/"
+            for row in report["issues"]:
+                file_val = row.get("file")
+                if isinstance(file_val, str):
+                    row["file"] = file_val.removeprefix(base)
+            (inv_dir / "formula_audit.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+            logger.info(
+                "Formula audit: %d file(s) with formulas, %d issue(s)",
+                report["files_with_formulas"],
+                report["total_issues"],
+            )
+        except Exception as exc:  # noqa: BLE001 — advisory; never block the run
+            logger.debug("Formula audit skipped: %s", exc)
+
+    def _per_agent_routes(self, state: PipelineState) -> dict[str, dict[str, str]]:
+        """Secret-free per-agent routing receipt for the report (Issue #240).
+
+        Mirrors what is persisted into RunMetadata.per_agent_routes, sourced from
+        the typed deal config's agent_models. Empty for a single-provider run.
+        """
+        typed_cfg = self._typed_deal_config(state) if state.deal_config else None
+        am = getattr(typed_cfg, "agent_models", None) if typed_cfg is not None else None
+        if am is not None and hasattr(am, "routing_receipt"):
+            result: dict[str, dict[str, str]] = am.routing_receipt()
+            return result
         return {}
 
     def _reconcile_request_list(self, state: PipelineState, files: list[Any], inv_dir: Path) -> None:
@@ -1641,6 +1692,8 @@ class PipelineEngine:
                 input_tokens=result.get("input_tokens_est", 0),
                 output_tokens=result.get("output_tokens_est", 0),
                 model=result.get("model", ""),
+                provider=result.get("provider"),
+                base_url=result.get("base_url"),
             )
 
             # Write per-agent audit log entry (DoD #11)
@@ -2491,6 +2544,8 @@ class PipelineEngine:
                 input_tokens=result.get("input_tokens_est", 0),
                 output_tokens=result.get("output_tokens_est", 0),
                 model=result.get("model", ""),
+                provider=result.get("provider"),
+                base_url=result.get("base_url"),
             )
 
             if result.get("is_error"):
@@ -2722,6 +2777,8 @@ class PipelineEngine:
             input_tokens=result.get("input_tokens_est", 0),
             output_tokens=result.get("output_tokens_est", 0),
             model=result.get("model", ""),
+            provider=result.get("provider"),
+            base_url=result.get("base_url"),
         )
 
         # Write per-agent audit log entry (DoD #11)
@@ -3568,6 +3625,10 @@ class PipelineEngine:
             # Per-model cost rollup (Issue #232) — surfaced in the report; flags
             # estimated (default-rate) models so non-Claude spend isn't shown as exact.
             "llm_cost_by_model": (ctm.cost_by_model() if (ctm := getattr(self, "cost_tracker", None)) else {}),
+            # Per-provider cost rollup + per-agent routing (Issue #240) — surfaced
+            # in the report's provenance section for mixed-provider runs.
+            "llm_cost_by_provider": (ctp.cost_by_provider() if (ctp := getattr(self, "cost_tracker", None)) else {}),
+            "llm_per_agent_routes": self._per_agent_routes(state),
         }
 
         inv_dir = self._inventory_dir(state)
@@ -3616,6 +3677,20 @@ class PipelineEngine:
         if diff_path.exists():
             with contextlib.suppress(json.JSONDecodeError, OSError):
                 run_metadata["report_diff"] = json.loads(diff_path.read_text(encoding="utf-8"))
+
+        # Request-list completeness (Issue #192/#238) — surface received vs.
+        # missing vs. unexpected in the report (HTML subsection + Excel sheet).
+        rl_path = inv_dir / "request_list.json"
+        if rl_path.exists():
+            with contextlib.suppress(json.JSONDecodeError, OSError):
+                run_metadata["request_list"] = json.loads(rl_path.read_text(encoding="utf-8"))
+
+        # Formula-integrity audit (Issue #194/#238) — surface model-integrity
+        # issues citing exact cells, independent of any agent finding.
+        fa_path = inv_dir / "formula_audit.json"
+        if fa_path.exists():
+            with contextlib.suppress(json.JSONDecodeError, OSError):
+                run_metadata["formula_audit"] = json.loads(fa_path.read_text(encoding="utf-8"))
 
         # Finding and gap counts from merged data
         total_findings = 0
@@ -3855,6 +3930,8 @@ class PipelineEngine:
                 input_tokens=es_result.get("input_tokens_est", 0),
                 output_tokens=es_result.get("output_tokens_est", 0),
                 model=es_result.get("model", ""),
+                provider=es_result.get("provider"),
+                base_url=es_result.get("base_url"),
             )
             state.agent_costs["executive_synthesis"] = es_result.get("cost_usd", 0.0)
 
@@ -3907,6 +3984,8 @@ class PipelineEngine:
                     input_tokens=ai_result.get("input_tokens_est", 0),
                     output_tokens=ai_result.get("output_tokens_est", 0),
                     model=ai_result.get("model", ""),
+                    provider=ai_result.get("provider"),
+                    base_url=ai_result.get("base_url"),
                 )
                 state.agent_costs["acquirer_intelligence"] = ai_result.get("cost_usd", 0.0)
 
@@ -4012,6 +4091,8 @@ class PipelineEngine:
                     input_tokens=narr_result.get("input_tokens_est", 0),
                     output_tokens=narr_result.get("output_tokens_est", 0),
                     model=narr_result.get("model", ""),
+                    provider=narr_result.get("provider"),
+                    base_url=narr_result.get("base_url"),
                 )
                 state.agent_costs["narrative_generation"] = narr_result.get("cost_usd", 0.0)
 
@@ -4136,6 +4217,14 @@ class PipelineEngine:
 
         routing = resolve_provider().as_receipt()
 
+        # Per-agent routing receipt (Issue #240): secret-free {agent → {model, base_url}}
+        # for mixed-provider audit. Empty for a single-provider run.
+        per_agent_routes: dict[str, dict[str, str]] = {}
+        typed_cfg = self._typed_deal_config(state) if state.deal_config else None
+        am = getattr(typed_cfg, "agent_models", None) if typed_cfg is not None else None
+        if am is not None and hasattr(am, "routing_receipt"):
+            per_agent_routes = am.routing_receipt()
+
         metadata = RunMetadata(
             run_id=state.run_id,
             timestamp=state.run_dir.name if state.run_dir else state.run_id,
@@ -4146,6 +4235,7 @@ class PipelineEngine:
             llm_provider=routing["provider"],  # type: ignore[arg-type]
             llm_base_url=routing["base_url"],  # type: ignore[arg-type]
             llm_models=self.cost_tracker.models_used(),
+            per_agent_routes=per_agent_routes,
             completion_status=CompletionStatus.COMPLETED,
             finding_counts=finding_counts,
             gap_counts=gap_counts,

--- a/src/dd_agents/orchestrator/team.py
+++ b/src/dd_agents/orchestrator/team.py
@@ -418,6 +418,11 @@ class AgentTeam:
         # rather than blank. Falls back to the registry's default model when no
         # selection is configured, so a run is never costed against "".
         model_id = ""
+        # Per-agent provider attribution for the cost/audit receipt (Issue #240):
+        # resolved from the same route as the model. (None, None) on the run-wide
+        # default route. Secret-free (host-only base_url).
+        route_provider: str | None = None
+        route_base_url: str | None = None
         if runner_cls is not None:
             try:
                 _tmp = runner_cls(
@@ -427,6 +432,8 @@ class AgentTeam:
                     deal_config=self._deal_config(),
                 )
                 model_id = (_tmp.get_model_id() if hasattr(_tmp, "get_model_id") else None) or ""
+                if hasattr(_tmp, "get_route_provider"):
+                    route_provider, route_base_url = _tmp.get_route_provider()
             except Exception:  # noqa: BLE001
                 pass
         cost_usd = _estimate_cost(model_id, total_input_tokens, total_output_tokens)
@@ -436,6 +443,8 @@ class AgentTeam:
             "status": status,
             "cost_usd": cost_usd,
             "model": model_id,
+            "provider": route_provider,
+            "base_url": route_base_url,
             "session_id": "",
             "num_turns": total_turns,
             "duration_ms": total_elapsed_ms,
@@ -489,12 +498,18 @@ class AgentTeam:
 
         model_id = (runner.get_model_id() if hasattr(runner, "get_model_id") else "") or ""
         cost_usd = _estimate_cost(model_id, input_tokens, output_tokens)
+        # Per-agent provider attribution for the cost/audit receipt (Issue #240).
+        route_provider, route_base_url = (
+            runner.get_route_provider() if hasattr(runner, "get_route_provider") else (None, None)
+        )
 
         return {
             "agent": AGENT_JUDGE,
             "status": "completed",
             "cost_usd": cost_usd,
             "model": model_id,
+            "provider": route_provider,
+            "base_url": route_base_url,
             "session_id": "",
             "num_turns": num_turns,
             "duration_ms": elapsed_ms,

--- a/src/dd_agents/reporting/excel.py
+++ b/src/dd_agents/reporting/excel.py
@@ -363,6 +363,8 @@ class ExcelReportGenerator:
             "Entity_Resolution_Log": self._data_entity_log,
             "Quality_Audit": self._data_quality_audit,
             "Run_Diff": self._data_run_diff,
+            "Request_List_Completeness": self._data_request_list,
+            "Model_Integrity": self._data_model_integrity,
             "_Metadata": self._data_metadata,
         }
 
@@ -537,6 +539,65 @@ class ExcelReportGenerator:
         diff = run_metadata.get("report_diff", {})
         result: list[dict[str, Any]] = diff.get("changes", [])
         return result
+
+    # -- Request-list completeness (Issue #192/#238) -------------------
+
+    def _data_request_list(
+        self,
+        merged: dict[str, dict[str, Any]],
+        deal_config: dict[str, Any],
+        run_metadata: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """One row per request-list status bucket. Empty when no request list."""
+        rl = run_metadata.get("request_list")
+        if not isinstance(rl, dict) or not rl:
+            return []
+        buckets = [
+            ("Received", rl.get("received", [])),
+            ("Missing — required", rl.get("missing_required", [])),
+            ("Missing — optional", rl.get("missing_optional", [])),
+        ]
+        rows: list[dict[str, Any]] = []
+        for status, items in buckets:
+            item_list = [str(i) for i in items if i] if isinstance(items, list) else []
+            rows.append({"status": status, "count": len(item_list), "items": ", ".join(item_list)})
+        rows.append(
+            {
+                "status": "Unexpected files",
+                "count": int(rl.get("unexpected_count", 0) or 0),
+                "items": "Files present but not on the request list (informational)",
+            }
+        )
+        return rows
+
+    # -- Model-integrity audit (Issue #194/#238) -----------------------
+
+    def _data_model_integrity(
+        self,
+        merged: dict[str, dict[str, Any]],
+        deal_config: dict[str, Any],
+        run_metadata: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """One row per detected formula-integrity issue. Empty when no formulas."""
+        fa = run_metadata.get("formula_audit")
+        if not isinstance(fa, dict) or not fa.get("files_with_formulas"):
+            return []
+        issues = fa.get("issues")
+        if not isinstance(issues, list):
+            return []
+        rows: list[dict[str, Any]] = []
+        for row in issues:
+            if isinstance(row, dict):
+                rows.append(
+                    {
+                        "file": str(row.get("file", "")),
+                        "sheet": str(row.get("sheet", "")),
+                        "cell": str(row.get("cell", "")),
+                        "kind": str(row.get("kind", "")),
+                        "detail": str(row.get("detail", "")),
+                    }
+                )
+        return rows
 
     # -- Metadata ------------------------------------------------------
 

--- a/src/dd_agents/reporting/excel.py
+++ b/src/dd_agents/reporting/excel.py
@@ -1,7 +1,8 @@
 """Schema-driven Excel report generator.
 
-Reads ``report_schema.json`` at runtime and produces the 14-sheet
-(10 always-active + 4 conditional) Excel workbook using openpyxl.
+Reads ``report_schema.json`` at runtime and produces the multi-sheet Excel
+workbook using openpyxl. The sheet set is defined entirely by the schema (the
+single source of truth) — never hardcode the count here.
 """
 
 from __future__ import annotations

--- a/src/dd_agents/reporting/html.py
+++ b/src/dd_agents/reporting/html.py
@@ -32,6 +32,7 @@ from dd_agents.reporting.html_analysis import (
     TfCAnalysisRenderer,
 )
 from dd_agents.reporting.html_base import render_css, render_js, render_nav_bar
+from dd_agents.reporting.html_completeness import CompletenessRenderer
 from dd_agents.reporting.html_compliance import ComplianceRenderer
 from dd_agents.reporting.html_config_panel import ConfigPanelRenderer
 from dd_agents.reporting.html_cross import CrossRefRenderer
@@ -278,6 +279,7 @@ class HTMLReportGenerator:
             IntegrationPlaybookRenderer(computed, merged_data, renderer_config),
             GovernanceGraphRenderer(computed, merged_data, renderer_config),
             GapRenderer(computed, merged_data, renderer_config),
+            CompletenessRenderer(computed, merged_data, renderer_config),
             SubjectRenderer(computed, merged_data, renderer_config),
             ConfigPanelRenderer(computed, merged_data, renderer_config),
             MethodologyRenderer(computed, merged_data, renderer_config),

--- a/src/dd_agents/reporting/html_base.py
+++ b/src/dd_agents/reporting/html_base.py
@@ -1348,6 +1348,7 @@ def render_nav_bar(section_rag: dict[str, str] | None = None) -> str:
         "<div class='toc-group-label'>Evidence</div>"
         "<a href='#sec-subjects'>Entity Detail</a>"
         f"<a href='#sec-gaps'>{_rag('gaps')} Data Gaps</a>"
+        "<a href='#sec-completeness'>Completeness</a>"
         "<a href='#sec-methodology'>Methodology</a>"
         "</div>"
         "<div class='sidebar-footer'>"

--- a/src/dd_agents/reporting/html_completeness.py
+++ b/src/dd_agents/reporting/html_completeness.py
@@ -1,0 +1,171 @@
+"""Data-room completeness + model-integrity renderer (Issue #238).
+
+Surfaces two deterministic, pre-computed artifacts that otherwise never reach
+the deliverable — they only lived in ``assess`` output, an inventory JSON, or
+the agent's prompt:
+
+1. **Request-list completeness** (``inventory/request_list.json``, Issue #192) —
+   received vs. missing-required vs. missing-optional expected documents, plus
+   the count of unexpected files.
+2. **Model-integrity audit** (``inventory/formula_audit.json``, Issue #194) —
+   spreadsheet formula issues (hardcoded overrides, circular refs, ``#REF!``,
+   broken external links) citing an exact ``file → Sheet!Cell``, independent of
+   whether the Finance agent also flagged them.
+
+Both are sourced from the persisted run metadata (mirrors how
+``MethodologyRenderer`` reads ``_run_metadata``). Parity-safe: the section
+renders nothing when neither artifact is present (a generic room adds nothing).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dd_agents.reporting.html_base import SectionRenderer
+
+# Human labels for the machine ``kind`` keys emitted by formula_audit.
+_KIND_LABELS: dict[str, str] = {
+    "hardcoded_override": "Hardcoded override",
+    "circular_reference": "Circular reference",
+    "error_literal": "Error literal (e.g. #REF!)",
+    "broken_external_link": "Broken external link",
+}
+
+
+class CompletenessRenderer(SectionRenderer):
+    """Render request-list completeness + model-integrity audit sub-sections."""
+
+    def render(self) -> str:
+        run_meta = (self.config or {}).get("_run_metadata") or {}
+        if not isinstance(run_meta, dict):
+            return ""
+        request_list = run_meta.get("request_list")
+        formula_audit = run_meta.get("formula_audit")
+
+        body: list[str] = []
+        if isinstance(request_list, dict) and request_list:
+            body.append(self._render_request_list(request_list))
+        if isinstance(formula_audit, dict) and formula_audit.get("files_with_formulas"):
+            body.append(self._render_formula_audit(formula_audit))
+
+        body = [b for b in body if b]
+        if not body:
+            return ""
+
+        parts: list[str] = [
+            "<section class='report-section' id='sec-completeness'>",
+            "<h2>Data-Room Completeness &amp; Model Integrity</h2>",
+            *body,
+            "</section>",
+        ]
+        return "\n".join(parts)
+
+    # -- Request-list completeness (Issue #192) ------------------------------
+
+    def _render_request_list(self, rl: dict[str, Any]) -> str:
+        received = [str(c) for c in rl.get("received", []) if c]
+        missing_required = [str(c) for c in rl.get("missing_required", []) if c]
+        missing_optional = [str(c) for c in rl.get("missing_optional", []) if c]
+        unexpected = int(rl.get("unexpected_count", 0) or 0)
+        summary = str(rl.get("summary", "")).strip()
+
+        parts: list[str] = [
+            "<div class='domain-section'>",
+            "<div class='domain-header' tabindex='0' role='button' aria-expanded='true'"
+            " style='border-left-color: var(--blue)'>",
+            "<h2>Request-List Completeness</h2>",
+            "<span class='arrow open'>&#9654;</span></div>",
+            "<div class='domain-body open'>",
+        ]
+        if summary:
+            # render_alert already escapes — pass raw text. Missing-required is a
+            # gap (critical framing); otherwise informational.
+            level = "high" if missing_required else "info"
+            parts.append(self.render_alert(level, "Completeness", summary))
+
+        parts.append(
+            "<table class='subject-table sortable'><caption>Requested-document reconciliation</caption>"
+            "<thead><tr><th scope='col'>Status</th><th scope='col'>Count</th>"
+            "<th scope='col'>Items</th></tr></thead><tbody>"
+        )
+        parts.append(self._rl_row("Received", received))
+        parts.append(self._rl_row("Missing — required", missing_required))
+        parts.append(self._rl_row("Missing — optional", missing_optional))
+        parts.append(
+            f"<tr><td>Unexpected files</td><td>{unexpected}</td>"
+            "<td class='text-muted'>Files present but not on the request list (informational)</td></tr>"
+        )
+        parts.append("</tbody></table>")
+        parts.append("</div></div>")
+        return "".join(parts)
+
+    def _rl_row(self, label: str, items: list[str]) -> str:
+        joined = ", ".join(self.escape(i) for i in items) if items else "<span class='text-muted'>—</span>"
+        return f"<tr><td>{self.escape(label)}</td><td>{len(items)}</td><td>{joined}</td></tr>"
+
+    # -- Model-integrity audit (Issue #194) ----------------------------------
+
+    def _render_formula_audit(self, fa: dict[str, Any]) -> str:
+        total = int(fa.get("total_issues", 0) or 0)
+        files_with_formulas = int(fa.get("files_with_formulas", 0) or 0)
+        files_with_issues = int(fa.get("files_with_issues", 0) or 0)
+        by_kind = fa.get("by_kind") or {}
+        issues = fa.get("issues") or []
+        truncated = bool(fa.get("truncated"))
+
+        # Collapsed by default — supplementary integrity evidence.
+        parts: list[str] = [
+            "<div class='domain-section'>",
+            "<div class='domain-header' tabindex='0' role='button' aria-expanded='false'"
+            " style='border-left-color: var(--orange)'>",
+            f"<h2>Model Integrity ({total})</h2>",
+            "<span class='arrow'>&#9654;</span></div>",
+            "<div class='domain-body'>",
+        ]
+
+        if total == 0:
+            parts.append(
+                self.render_alert(
+                    "good",
+                    "Model integrity",
+                    f"No formula-integrity issues detected across {files_with_formulas} spreadsheet(s) with formulas.",
+                )
+            )
+            parts.append("</div></div>")
+            return "".join(parts)
+
+        parts.append(
+            self.render_alert(
+                "high",
+                "Model integrity",
+                f"{total} potential issue(s) across {files_with_issues} of {files_with_formulas} "
+                "spreadsheet(s) with formulas. Each cites an exact cell — verify before relying on the model.",
+            )
+        )
+
+        if isinstance(by_kind, dict) and by_kind:
+            kind_bits = ", ".join(
+                f"{self.escape(_KIND_LABELS.get(str(k), str(k)))}: {v}" for k, v in sorted(by_kind.items())
+            )
+            parts.append(f"<p><strong>By type:</strong> {kind_bits}</p>")
+
+        parts.append(
+            "<table class='subject-table sortable'><caption>Formula-integrity issues</caption>"
+            "<thead><tr><th scope='col'>File</th><th scope='col'>Cell</th>"
+            "<th scope='col'>Type</th><th scope='col'>Detail</th></tr></thead><tbody>"
+        )
+        for row in issues:
+            if not isinstance(row, dict):
+                continue
+            file = self.escape(str(row.get("file", "")))
+            sheet = str(row.get("sheet", ""))
+            cell = str(row.get("cell", ""))
+            location = self.escape(f"{sheet}!{cell}" if sheet else cell)
+            kind = self.escape(_KIND_LABELS.get(str(row.get("kind", "")), str(row.get("kind", ""))))
+            detail = self.escape(str(row.get("detail", "")))
+            parts.append(f"<tr><td>{file}</td><td>{location}</td><td>{kind}</td><td>{detail}</td></tr>")
+        parts.append("</tbody></table>")
+        if truncated:
+            parts.append("<p class='text-muted'>Note: issue list truncated to a bounded cap.</p>")
+        parts.append("</div></div>")
+        return "".join(parts)

--- a/src/dd_agents/reporting/html_methodology.py
+++ b/src/dd_agents/reporting/html_methodology.py
@@ -70,6 +70,51 @@ class MethodologyRenderer(SectionRenderer):
                             "<tbody>" + "".join(rows) + "</tbody></table>"
                         )
 
+                # Per-provider cost rollup (Issue #240). Only meaningful for a
+                # mixed-provider run (per-agent routing); a single-provider run
+                # rolls up under one "(run default)" bucket, so render the table
+                # only when more than one provider bucket exists.
+                cost_by_provider = run_meta.get("llm_cost_by_provider") or {}
+                if isinstance(cost_by_provider, dict) and len(cost_by_provider) > 1:
+                    prov_rows: list[str] = []
+                    for prov_id, info in sorted(cost_by_provider.items()):
+                        if not isinstance(info, dict):
+                            continue
+                        cost = info.get("cost", 0.0)
+                        host = info.get("base_url")
+                        host_str = f" <span class='text-muted'>({self.escape(str(host))})</span>" if host else ""
+                        prov_rows.append(
+                            f"<tr><td>{self.escape(str(prov_id))}{host_str}</td><td>${cost:,.2f}</td></tr>"
+                        )
+                    if prov_rows:
+                        parts.append(
+                            "<table class='subject-table'><caption>Estimated cost by provider</caption>"
+                            "<thead><tr><th scope='col'>Provider</th><th scope='col'>Est. cost (USD)</th></tr>"
+                            "</thead><tbody>" + "".join(prov_rows) + "</tbody></table>"
+                        )
+
+                # Per-agent routing receipt (Issue #240): which agents ran on a
+                # non-default route. Secret-free (host-only). Rendered only when
+                # per-agent routes were configured (mixed-provider run).
+                per_agent_routes = run_meta.get("llm_per_agent_routes") or {}
+                if isinstance(per_agent_routes, dict) and per_agent_routes:
+                    route_rows: list[str] = []
+                    for agent_name, route in sorted(per_agent_routes.items()):
+                        if not isinstance(route, dict):
+                            continue
+                        model = self.escape(str(route.get("model", "—")))
+                        host = self.escape(str(route.get("base_url", "—")))
+                        route_rows.append(
+                            f"<tr><td>{self.escape(str(agent_name))}</td><td>{model}</td><td>{host}</td></tr>"
+                        )
+                    if route_rows:
+                        parts.append(
+                            "<table class='subject-table'><caption>Per-agent routing</caption>"
+                            "<thead><tr><th scope='col'>Agent</th><th scope='col'>Model</th>"
+                            "<th scope='col'>Gateway</th></tr></thead>"
+                            "<tbody>" + "".join(route_rows) + "</tbody></table>"
+                        )
+
         # Key stats
         parts.append(
             "<div class='metrics-strip'>"

--- a/src/dd_agents/reporting/ic_memo.py
+++ b/src/dd_agents/reporting/ic_memo.py
@@ -157,6 +157,13 @@ def render_ic_memo(computed: ReportComputedData, deal_config: dict[str, Any] | N
 
     Pure + side-effect-free; same input → same output. Sections with no data are
     omitted so the memo stays clean for thin deals.
+
+    Language: the memo is **language-agnostic by design**. Its fixed scaffolding
+    (headings, labels) is English, but every substantive cell — finding titles,
+    descriptions, evidence quotes, recommendations — is passed through verbatim
+    from the findings. So when ``deal.output_language`` drove the specialists to
+    write findings in another language, those appear in the memo unchanged; no
+    separate translation pass exists or is needed.
     """
     parts: list[str] = []
     parts += _deal_header(deal_config)

--- a/tests/integration/test_v115_features.py
+++ b/tests/integration/test_v115_features.py
@@ -1,0 +1,168 @@
+"""End-to-end coverage for v1.13/v1.14/v1.15 features that were unit-tested in
+isolation but lacked an integration proof (Issue #242).
+
+Covers, without spawning agents or needing an API key:
+- Per-agent routing env reaches ``ClaudeAgentOptions.env`` (config → get_route_env
+  → build_agent_options(extra_env=) → SDK seam). (#233/#240)
+- ``dd-agents assess --config`` reconciles a request list over a real tmp data
+  room (CLI → DataRoomAssessor → request-list reconcile). (#192)
+- The formula-integrity section a Finance agent consumes stays format-stable for
+  a workbook with a known model defect. (#194)
+- The IC memo passes non-English finding text through verbatim (language-agnostic
+  by design — no translation pass). (#190)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestPerAgentRoutingEnvWiring:
+    """config → get_route_env → build_agent_options(extra_env=) → SDK options.env."""
+
+    def test_route_env_reaches_claude_agent_options(self, tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+        from dd_agents.agents.specialists import LegalAgent
+        from dd_agents.llm import build_agent_options
+        from dd_agents.models.config import AgentRoute, DealConfig
+
+        monkeypatch.setenv("MY_GW_TOKEN", "sk-secret-value")  # pragma: allowlist secret
+        cfg = DealConfig.model_validate(
+            {
+                "config_version": "1.0.0",
+                "buyer": {"name": "B"},
+                "target": {"name": "T"},
+                "deal": {"type": "acquisition", "focus_areas": ["ip_ownership"]},
+                "agent_models": {
+                    "routes": {
+                        "legal": AgentRoute(base_url="http://gateway:4011", auth_token_env="MY_GW_TOKEN").model_dump()
+                    }
+                },
+            }
+        )
+        runner = LegalAgent(project_dir=tmp_path, run_dir=tmp_path, run_id="r", deal_config=cfg)
+
+        route_env = runner.get_route_env()
+        # The seam forwards extra_env onto the per-call CLI subprocess env.
+        options = build_agent_options(model=runner.get_model_id(), extra_env=route_env)
+
+        assert options.env["ANTHROPIC_BASE_URL"] == "http://gateway:4011"
+        assert options.env["ANTHROPIC_AUTH_TOKEN"] == "sk-secret-value"  # pragma: allowlist secret
+
+    def test_route_provider_attribution_is_secret_free(self, tmp_path: Path) -> None:
+        from dd_agents.agents.specialists import LegalAgent
+        from dd_agents.models.config import AgentRoute, DealConfig
+
+        cfg = DealConfig.model_validate(
+            {
+                "config_version": "1.0.0",
+                "buyer": {"name": "B"},
+                "target": {"name": "T"},
+                "deal": {"type": "acquisition", "focus_areas": ["ip_ownership"]},
+                "agent_models": {"routes": {"legal": AgentRoute(base_url="http://gw:4011").model_dump()}},
+            }
+        )
+        runner = LegalAgent(project_dir=tmp_path, run_dir=tmp_path, run_id="r", deal_config=cfg)
+        provider, base_url = runner.get_route_provider()
+        assert provider == "gateway"
+        assert base_url == "http://gw:4011"
+
+
+class TestAssessConfigRequestList:
+    """dd-agents assess --config reconciles a request list over a real data room."""
+
+    def test_assess_config_reports_received_and_missing(self, tmp_path: Path) -> None:
+        from dd_agents.cli import main
+
+        data_room = tmp_path / "dr"
+        (data_room / "Acme").mkdir(parents=True)
+        # One file satisfies "Signed MSA"; the required "Audited Financials" is absent.
+        (data_room / "Acme" / "msa_signed.pdf").write_text("x")
+        (data_room / "Acme" / "extra_notes.pdf").write_text("y")
+
+        config = {
+            "config_version": "1.0.0",
+            "buyer": {"name": "B"},
+            "target": {"name": "T"},
+            "deal": {"type": "acquisition", "focus_areas": ["ip_ownership"]},
+            "data_room": {"path": str(data_room)},
+            "request_list": {
+                "enabled": True,
+                "items": [
+                    {"category": "Signed MSA", "keywords": ["msa", "signed"], "required": True},
+                    {"category": "Audited Financials", "keywords": ["audited", "financials"], "required": True},
+                ],
+            },
+        }
+        config_path = tmp_path / "deal-config.json"
+        config_path.write_text(json.dumps(config))
+
+        result = CliRunner().invoke(main, ["assess", str(data_room), "--config", str(config_path)])
+        assert result.exit_code == 0, result.output
+        # The reconciliation summary appears in the assess output.
+        out = result.output.lower()
+        assert "request" in out or "received" in out or "missing" in out
+
+
+class TestFormulaAuditFindingFormat:
+    """The Finance agent's Formula Integrity section stays format-stable (#194)."""
+
+    def test_section_cites_defect_for_known_bad_model(self, tmp_path: Path) -> None:
+        from openpyxl import Workbook
+
+        from dd_agents.tools.read_office import _formula_audit_section
+
+        p = tmp_path / "model.xlsx"
+        wb = Workbook()
+        ws = wb.active
+        ws.title = "P&L"
+        # A column of real formulas with one hardcoded override → a known defect.
+        ws["B2"] = "=A2*1.1"
+        ws["B3"] = "=A3*1.1"
+        ws["B4"] = "=A4*1.1"
+        ws["B5"] = "=1234"  # hardcoded numeric "formula" overriding a computed cell
+        wb.save(p)
+        wb.close()
+
+        section = _formula_audit_section(p)
+        assert "Formula Integrity" in section
+        # The exact-cell citation a specialist would quote must be present.
+        assert "B5" in section
+        assert "hardcoded_override" in section
+
+
+class TestICMemoLanguagePassthrough:
+    """The IC memo passes non-English finding text through verbatim (#190)."""
+
+    def test_non_english_finding_text_preserved(self) -> None:
+        from dd_agents.reporting.computed_metrics import ReportDataComputer
+        from dd_agents.reporting.ic_memo import render_ic_memo
+
+        # A P0 finding written in French (as deal.output_language would produce).
+        french_title = "Clause de changement de contrôle déclenchée"
+        merged = {
+            "targetco": {
+                "subject": "TargetCo",
+                "subject_safe_name": "targetco",
+                "findings": [
+                    {
+                        "id": "F1",
+                        "agent": "legal",
+                        "severity": "P0",
+                        "title": french_title,
+                        "description": "Le contrat exige le consentement écrit du fournisseur.",
+                        "citation": {"source_path": "msa.pdf", "location": "§7.2", "exact_quote": "consentement"},
+                    }
+                ],
+                "gaps": [],
+            }
+        }
+        computed = ReportDataComputer().compute(merged)
+        memo = render_ic_memo(computed, {"buyer": {"name": "B"}, "target": {"name": "TargetCo"}})
+        # The non-English finding text appears unchanged — no translation pass.
+        assert french_title in memo

--- a/tests/unit/test_completeness_report.py
+++ b/tests/unit/test_completeness_report.py
@@ -1,0 +1,143 @@
+"""Tests for surfacing request-list completeness + model-integrity in reports (Issue #238).
+
+Covers the HTML CompletenessRenderer (request-list + formula audit, XSS-safe,
+parity when absent) and the two Excel data handlers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dd_agents.reporting.computed_metrics import ReportDataComputer
+from dd_agents.reporting.excel import ExcelReportGenerator
+from dd_agents.reporting.html_completeness import CompletenessRenderer
+
+
+def _computed() -> Any:
+    return ReportDataComputer().compute({})
+
+
+def _render(run_metadata: dict[str, Any] | None) -> str:
+    config = {"_run_metadata": run_metadata}
+    return CompletenessRenderer(_computed(), {}, config).render()
+
+
+class TestCompletenessRendererParity:
+    def test_empty_when_no_metadata(self) -> None:
+        assert _render(None) == ""
+        assert _render({}) == ""
+
+    def test_empty_when_no_artifacts(self) -> None:
+        assert _render({"llm_provider": "anthropic"}) == ""
+
+    def test_formula_audit_with_no_formulas_renders_nothing(self) -> None:
+        assert _render({"formula_audit": {"files_with_formulas": 0, "issues": []}}) == ""
+
+
+class TestRequestListSection:
+    def test_renders_received_and_missing(self) -> None:
+        rl = {
+            "summary": "2/3 expected items received, 1 required missing.",
+            "received": ["Signed MSA", "Cap Table"],
+            "missing_required": ["Audited Financials"],
+            "missing_optional": [],
+            "unexpected_count": 4,
+        }
+        html = _render({"request_list": rl})
+        assert "Request-List Completeness" in html
+        assert "Signed MSA" in html
+        assert "Audited Financials" in html
+        assert "id='sec-completeness'" in html
+        # Unexpected count surfaced.
+        assert "4" in html
+
+    def test_request_list_escapes_items(self) -> None:
+        rl = {
+            "summary": "x",
+            "received": ["<script>alert(1)</script>"],
+            "missing_required": [],
+            "missing_optional": [],
+            "unexpected_count": 0,
+        }
+        html = _render({"request_list": rl})
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+
+class TestModelIntegritySection:
+    def test_renders_issues_citing_cells(self) -> None:
+        fa = {
+            "files_with_formulas": 2,
+            "files_with_issues": 1,
+            "total_issues": 2,
+            "by_kind": {"hardcoded_override": 1, "circular_reference": 1},
+            "issues": [
+                {
+                    "file": "Acme/model.xlsx",
+                    "sheet": "P&L",
+                    "cell": "B5",
+                    "kind": "hardcoded_override",
+                    "detail": "Hardcoded value 1234",
+                },
+                {
+                    "file": "Acme/model.xlsx",
+                    "sheet": "P&L",
+                    "cell": "C3",
+                    "kind": "circular_reference",
+                    "detail": "Cell references itself",
+                },
+            ],
+            "truncated": False,
+        }
+        html = _render({"formula_audit": fa})
+        assert "Model Integrity (2)" in html
+        assert "P&amp;L!B5" in html
+        assert "Hardcoded override" in html
+
+    def test_clean_audit_shows_good_alert(self) -> None:
+        fa = {"files_with_formulas": 3, "files_with_issues": 0, "total_issues": 0, "by_kind": {}, "issues": []}
+        html = _render({"formula_audit": fa})
+        assert "No formula-integrity issues" in html
+
+    def test_model_integrity_escapes_detail(self) -> None:
+        fa = {
+            "files_with_formulas": 1,
+            "files_with_issues": 1,
+            "total_issues": 1,
+            "by_kind": {"error_literal": 1},
+            "issues": [{"file": "<x>", "sheet": "S", "cell": "A1", "kind": "error_literal", "detail": "<img src=x>"}],
+            "truncated": False,
+        }
+        html = _render({"formula_audit": fa})
+        assert "<img src=x>" not in html
+        assert "&lt;img" in html
+
+
+class TestExcelHandlers:
+    def test_request_list_handler_rows(self) -> None:
+        gen = ExcelReportGenerator()
+        rl = {"received": ["A", "B"], "missing_required": ["C"], "missing_optional": ["D"], "unexpected_count": 2}
+        rows = gen._data_request_list({}, {}, {"request_list": rl})
+        statuses = {r["status"]: r for r in rows}
+        assert statuses["Received"]["count"] == 2
+        assert statuses["Missing — required"]["count"] == 1
+        assert statuses["Unexpected files"]["count"] == 2
+
+    def test_request_list_handler_empty_when_absent(self) -> None:
+        gen = ExcelReportGenerator()
+        assert gen._data_request_list({}, {}, {}) == []
+
+    def test_model_integrity_handler_rows(self) -> None:
+        gen = ExcelReportGenerator()
+        fa = {
+            "files_with_formulas": 1,
+            "issues": [{"file": "m.xlsx", "sheet": "S", "cell": "A1", "kind": "error_literal", "detail": "d"}],
+        }
+        rows = gen._data_model_integrity({}, {}, {"formula_audit": fa})
+        assert len(rows) == 1
+        assert rows[0]["cell"] == "A1"
+
+    def test_model_integrity_handler_empty_when_no_formulas(self) -> None:
+        gen = ExcelReportGenerator()
+        assert gen._data_model_integrity({}, {}, {"formula_audit": {"files_with_formulas": 0}}) == []
+        assert gen._data_model_integrity({}, {}, {}) == []

--- a/tests/unit/test_completeness_report.py
+++ b/tests/unit/test_completeness_report.py
@@ -141,3 +141,41 @@ class TestExcelHandlers:
         gen = ExcelReportGenerator()
         assert gen._data_model_integrity({}, {}, {"formula_audit": {"files_with_formulas": 0}}) == []
         assert gen._data_model_integrity({}, {}, {}) == []
+
+
+class TestEmptyRoomParity:
+    """The 2 new sheets stay strictly headers-only for a generic room (HTML/Excel parity).
+
+    Regression guard for the audit finding: Model_Integrity must NOT write a
+    phantom TOTAL footer when there is no formula data (it would imply an audit
+    ran), matching the HTML CompletenessRenderer which renders nothing.
+    """
+
+    def _generate_empty(self, tmp_path: Any) -> Any:
+        import pathlib
+
+        from dd_agents.models.reporting import ReportSchema
+
+        repo_root = pathlib.Path(__file__).resolve().parents[2]
+        schema = ReportSchema.model_validate_json((repo_root / "config" / "report_schema.json").read_text())
+        out = tmp_path / "r.xlsx"
+        ExcelReportGenerator().generate(
+            {"s": {"subject": "S", "findings": [], "gaps": []}},
+            schema,
+            out,
+            deal_config={},
+            run_metadata={},
+        )
+        from openpyxl import load_workbook
+
+        return load_workbook(out)
+
+    def test_new_sheets_are_headers_only_when_empty(self, tmp_path: Any) -> None:
+        wb = self._generate_empty(tmp_path)
+        # max_row == 1 means headers only (no data, no summary footer).
+        assert wb["Model_Integrity"].max_row == 1
+        assert wb["Request_List_Completeness"].max_row == 1
+
+    def test_html_renders_nothing_for_same_empty_room(self) -> None:
+        # Parity counterpart: HTML section is absent for a generic room.
+        assert CompletenessRenderer(_computed(), {}, {"_run_metadata": {}}).render() == ""

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -235,10 +235,29 @@ class TestV113ConfigBlocks:
         assert "vdr_overrides" in data.get("precedence", {}), "template must document precedence.vdr_overrides (#193)"
         assert "extraction" in data, "template should surface extraction.ocr_backend"
 
+    def test_template_has_agent_models(self) -> None:
+        # Per-agent profiles/overrides/routes are production features (#129/#233);
+        # the template must surface them so users can discover them (#242).
+        data = json.loads(self._TEMPLATE.read_text(encoding="utf-8"))
+        am = data.get("agent_models")
+        assert isinstance(am, dict), "template must document agent_models (#129/#233)"
+        assert {"profile", "overrides", "routes"} <= set(am), "agent_models must show profile/overrides/routes"
+        # The illustrative example must keep gateway auth secret-safe: an env-var
+        # NAME in auth_token_env, never a literal token, and no creds in base_url.
+        example = am.get("_routes_example", {})
+        flat = json.dumps(example)
+        assert "auth_token_env" in flat, "example must show auth_token_env (the secret-safe pattern)"
+        judge = example.get("judge", {})
+        if judge.get("base_url"):
+            assert "@" not in judge["base_url"], "example base_url must not embed credentials"
+
     def test_template_validates_as_deal_config(self) -> None:
         cfg = DealConfig.model_validate(json.loads(self._TEMPLATE.read_text(encoding="utf-8")))
         assert cfg.precedence is not None and isinstance(cfg.precedence.vdr_overrides, dict)
         assert cfg.request_list is not None and len(cfg.request_list.items) >= 1
+        # agent_models present and inert by default (empty routes → parity).
+        assert cfg.agent_models is not None
+        assert cfg.agent_models.routes == {}
 
     def test_vdr_overrides_round_trips(self) -> None:
         cfg = DealConfig.model_validate(

--- a/tests/unit/test_cost_tracker.py
+++ b/tests/unit/test_cost_tracker.py
@@ -330,3 +330,131 @@ class TestCostByModel:
         d = t.to_dict()
         assert "by_model" in d
         assert "claude-opus-4-8" in d["by_model"]
+
+
+class TestCostByProvider:
+    """Per-provider cost rollup for mixed-provider runs (Issue #240)."""
+
+    def test_default_route_rolls_up_under_run_default(self) -> None:
+        from dd_agents.agents.cost_tracker import CostTracker
+
+        t = CostTracker()
+        # No per-agent provider → run-wide default bucket.
+        t.record("legal", "16_spawn", 1_000_000, 0, "claude-sonnet-4-6")
+        t.record("finance", "16_spawn", 1_000_000, 0, "claude-sonnet-4-6")
+        by_provider = t.cost_by_provider()
+        assert set(by_provider) == {"(run default)"}
+        assert by_provider["(run default)"]["input_tokens"] == 2_000_000
+        assert by_provider["(run default)"]["base_url"] is None
+
+    def test_mixed_provider_splits_into_buckets(self) -> None:
+        from dd_agents.agents.cost_tracker import CostTracker
+
+        t = CostTracker()
+        t.record("judge", "19_spawn_judge", 1_000_000, 0, "claude-sonnet-4-6")  # default route
+        t.record(
+            "red_flag_scanner",
+            "33_generate_reports",
+            1_000_000,
+            0,
+            "deepseek-v3",
+            provider="gateway",
+            base_url="http://gw:4011",
+        )
+        by_provider = t.cost_by_provider()
+        assert set(by_provider) == {"(run default)", "gateway"}
+        assert by_provider["gateway"]["base_url"] == "http://gw:4011"
+        assert by_provider["gateway"]["cost"] > 0
+
+    def test_multiple_gateways_yield_ambiguous_base_url(self) -> None:
+        from dd_agents.agents.cost_tracker import CostTracker
+
+        t = CostTracker()
+        t.record("legal", "16_spawn", 100, 0, "m1", provider="gateway", base_url="http://gw1")
+        t.record("finance", "16_spawn", 100, 0, "m2", provider="gateway", base_url="http://gw2")
+        by_provider = t.cost_by_provider()
+        # Two distinct hosts under one provider → base_url is None (unambiguous).
+        assert by_provider["gateway"]["base_url"] is None
+
+    def test_to_dict_includes_by_provider(self) -> None:
+        from dd_agents.agents.cost_tracker import CostTracker
+
+        t = CostTracker()
+        t.record("legal", "16_spawn", 100, 50, "claude-opus-4-8")
+        d = t.to_dict()
+        assert "by_provider" in d
+        assert "(run default)" in d["by_provider"]
+
+    def test_entry_carries_provider_and_base_url(self) -> None:
+        from dd_agents.agents.cost_tracker import CostTracker
+
+        t = CostTracker()
+        e = t.record("hr", "16_spawn", 10, 10, "m", provider="gateway", base_url="http://gw")
+        assert e.provider == "gateway"
+        assert e.base_url == "http://gw"
+
+
+class TestRoutingReceipt:
+    """Secret-free per-agent routing receipt for the audit trail (Issue #240)."""
+
+    def test_empty_when_no_routes(self) -> None:
+        am = AgentModelsConfig(profile="standard")
+        assert am.routing_receipt() == {}
+
+    def test_receipt_includes_model_and_safe_base_url(self) -> None:
+        from dd_agents.models.config import AgentRoute
+
+        am = AgentModelsConfig(
+            routes={
+                "judge": AgentRoute(model="claude-opus-4-8"),
+                "red_flag_scanner": AgentRoute(base_url="http://gw:4011", auth_token_env="MY_TOK"),
+            }
+        )
+        receipt = am.routing_receipt()
+        assert receipt["judge"] == {"model": "claude-opus-4-8"}
+        # base_url present, host-only; auth_token_env NEVER in the receipt.
+        assert receipt["red_flag_scanner"]["base_url"] == "http://gw:4011"
+        assert "auth_token_env" not in receipt["red_flag_scanner"]
+        assert "MY_TOK" not in str(receipt)
+
+    def test_credentialed_url_stripped_in_receipt(self) -> None:
+        from dd_agents.models.config import AgentRoute
+
+        # safe_base_url strips userinfo even if model_construct bypasses validation.
+        route = AgentRoute.model_construct(base_url="https://tok:pw@gw.example/v1")  # pragma: allowlist secret
+        am = AgentModelsConfig()
+        am.routes = {"legal": route}
+        receipt = am.routing_receipt()
+        assert receipt["legal"]["base_url"] == "https://gw.example/v1"
+        assert "pw@" not in str(receipt) and "tok:" not in str(receipt)
+
+
+class TestPerAgentRoutesPersistence:
+    """RunMetadata round-trips the per-agent routing receipt (Issue #240)."""
+
+    def test_run_metadata_round_trips_routes(self) -> None:
+        from dd_agents.models.enums import ExecutionMode
+        from dd_agents.models.persistence import RunMetadata
+
+        meta = RunMetadata(
+            run_id="r1",
+            timestamp="2026-06-10",
+            execution_mode=ExecutionMode.FULL,
+            config_hash="h",
+            per_agent_routes={"judge": {"model": "claude-opus-4-8", "base_url": "http://gw"}},
+        )
+        dumped = meta.model_dump(mode="json")
+        restored = RunMetadata.model_validate(dumped)
+        assert restored.per_agent_routes["judge"]["base_url"] == "http://gw"
+
+    def test_per_agent_routes_defaults_empty(self) -> None:
+        from dd_agents.models.enums import ExecutionMode
+        from dd_agents.models.persistence import RunMetadata
+
+        meta = RunMetadata(
+            run_id="r1",
+            timestamp="2026-06-10",
+            execution_mode=ExecutionMode.FULL,
+            config_hash="h",
+        )
+        assert meta.per_agent_routes == {}

--- a/tests/unit/test_formula_audit.py
+++ b/tests/unit/test_formula_audit.py
@@ -162,3 +162,59 @@ class TestReadOfficeIntegration:
         assert result["status"] == "ok"
         # No formulas → no audit section appended (non-model spreadsheets stay clean).
         assert "Formula Integrity" not in result["content"]
+
+
+class TestAuditDataRoom:
+    """Data-room-level aggregation reused by the report (Issue #238)."""
+
+    def test_empty_when_no_xlsx(self, tmp_path: Path) -> None:
+        from dd_agents.extraction.formula_audit import audit_data_room
+
+        (tmp_path / "a.txt").write_text("x")
+        report = audit_data_room([tmp_path / "a.txt"])
+        assert report["files_scanned"] == 0
+        assert report["files_with_formulas"] == 0
+        assert report["issues"] == []
+
+    def test_aggregates_issues_with_file_attribution(self, tmp_path: Path) -> None:
+        from dd_agents.extraction.formula_audit import audit_data_room
+
+        good = tmp_path / "values.xlsx"
+        _write_xlsx(good, {"Data": {"A1": 1, "A2": 2}})  # no formulas
+        bad = tmp_path / "model.xlsx"
+        _write_xlsx(
+            bad,
+            {"Model": {"B2": "=A2*1.1", "B3": "=A3*1.1", "B4": "=A4*1.1", "B5": "=1234"}},
+        )
+        report = audit_data_room([good, bad])
+        assert report["files_scanned"] == 2
+        assert report["files_with_formulas"] == 1
+        assert report["files_with_issues"] == 1
+        assert report["total_issues"] >= 1
+        # Every issue cites its originating file.
+        assert all(r["file"] == str(bad) for r in report["issues"])
+        assert "hardcoded_override" in report["by_kind"]
+
+    def test_truncation_flagged_not_silent(self, tmp_path: Path) -> None:
+        from dd_agents.extraction.formula_audit import audit_data_room
+
+        p = tmp_path / "model.xlsx"
+        # Many overrides in one column → exceed a tiny max_issues cap.
+        cells = {f"B{r}": f"=A{r}*1.1" for r in range(2, 8)}
+        cells["B20"] = "=11"
+        cells["B21"] = "=22"
+        cells["B22"] = "=33"
+        _write_xlsx(p, {"M": cells})
+        report = audit_data_room([p], max_issues=1)
+        assert report["truncated"] is True
+        assert len(report["issues"]) == 1
+
+    def test_result_is_json_serializable(self, tmp_path: Path) -> None:
+        import json
+
+        from dd_agents.extraction.formula_audit import audit_data_room
+
+        p = tmp_path / "m.xlsx"
+        _write_xlsx(p, {"S": {"C1": "=[1]Ext!A1"}})
+        report = audit_data_room([p])
+        json.dumps(report)  # must not raise

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -2856,13 +2856,27 @@ class TestReportSchemaPackageResolution:
         raise FileNotFoundError(msg)
 
     def test_config_schema_exists_in_repo(self) -> None:
-        """The 14-sheet report schema exists at repo_root/config/report_schema.json."""
+        """The report schema exists at repo_root/config/report_schema.json.
+
+        The repo copy and the wheel-bundled copy must define the SAME sheets
+        (the package mirror is generated from the source of truth) — assert
+        equality rather than a hardcoded count so the guard tracks the schema.
+        """
         repo_root = self._repo_root()
         schema_path = repo_root / "config" / "report_schema.json"
         assert schema_path.exists(), f"Expected schema at {schema_path}"
 
         schema = ReportSchema.model_validate_json(schema_path.read_text())
-        assert len(schema.sheets) == 14
+        assert len(schema.sheets) >= 1
+
+        import dd_agents as _pkg
+
+        bundled = Path(_pkg.__file__).resolve().parent / "config" / "report_schema.json"
+        bundled_schema = ReportSchema.model_validate_json(bundled.read_text())
+        assert [s.name for s in schema.sheets] == [s.name for s in bundled_schema.sheets], (
+            "Repo config/report_schema.json and the bundled package copy have drifted — "
+            "re-sync src/dd_agents/config/report_schema.json from config/report_schema.json."
+        )
 
     def test_bundled_schema_exists_in_package(self) -> None:
         """The schema is bundled inside the dd_agents package for wheel installs."""
@@ -2873,7 +2887,7 @@ class TestReportSchemaPackageResolution:
         assert bundled.exists(), f"Expected bundled schema at {bundled}"
 
         schema = ReportSchema.model_validate_json(bundled.read_text())
-        assert len(schema.sheets) == 14
+        assert len(schema.sheets) >= 1
 
     def test_package_relative_resolution_order(self, tmp_path: Path) -> None:
         """Resolution finds schema via bundled package path when project_dir has none."""


### PR DESCRIPTION
Folds three issues into one release. Zero new dependencies; all layers green.

## #240 — per-provider cost + per-agent routing audit receipt
A mixed-provider run (per-agent routing, #233) is now fully auditable.
- `AgentCostEntry` gains secret-free `provider`/`base_url`; `CostTracker.record(...)` accepts them; new `cost_by_provider()` rollup + `to_dict` `by_provider`.
- `base.py:get_route_provider()` + `team.py`/judge thread `(provider, safe_base_url)` into every cost record site.
- `AgentModelsConfig.routing_receipt()` (secret-free) → `RunMetadata.per_agent_routes`, persisted at finalize + mirrored into report metadata.
- Methodology renderer adds per-provider cost + per-agent routing tables (shown only for mixed-provider runs).

## #238 — surface request-list completeness + formula-integrity in the report
Two shipped-but-buried capabilities now reach the deliverable.
- `formula_audit.audit_data_room()` aggregates the pure per-workbook detector into a JSON-safe, bounded report.
- Engine step 06 persists `inventory/formula_audit.json`; it + `request_list.json` load into report metadata.
- New `CompletenessRenderer` (HTML) + 2 always-present Excel sheets (`Request_List_Completeness`, `Model_Integrity`) → schema 14→16.
- Parity-safe: renders nothing (and sheets stay headers-only) for a generic room.

## #242 — docs / template / integration-test polish
- `agent_models` block (with secret-safe `auth_token_env` example) in the deal-config template + assertion.
- `chat -q` documented; `(estimated)` cost label + Generation Provenance documented; IC-memo language-passthrough docstring.
- 4 integration tests: per-agent routing env wiring, `assess --config` request-list, formula-audit section format, non-English IC memo passthrough.

## Quality
- **16-agent adversarial audit** → 11 raw findings, 9 refuted on verification, **2 confirmed (both minor), both fixed**: Model_Integrity sheet now headers-only when empty (HTML/Excel parity); excel.py docstring de-hardcoded (points to schema).
- 4447 unit + integration pass; deterministic evals pass; `mypy --strict` clean; `ruff` + `ruff format` clean; `mkdocs build` clean; docs-drift guard green.
- Both `report_schema.json` copies (repo + wheel-bundled mirror) verified identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)