### PR TITLE
v1.16.0 — formula→findings + HTML/PDF parity + vision-cost accounting (#245, #244, #247)

### DIFF
--- a/docs/user-guide/reading-report.md
+++ b/docs/user-guide/reading-report.md
@@ -38,7 +38,9 @@ The report uses a 4-layer progressive disclosure design. You get the answer firs
 - Clause library, key employee, tech stack, product adoption
 - Cross-reference reconciliation, entity health tiers
 - Recommendations, integration playbook, governance graph
-- Data gaps, per-entity detail, methodology, data quality
+- Contract date reconciliation (active-vs-expired ARR), entity-resolution log
+- Data gaps, data-room completeness & model integrity, reference files
+- Per-entity detail, methodology, data quality
 
 ### Navigation
 
@@ -126,8 +128,16 @@ The Excel report at `dd_report.xlsx` contains 16 sheets:
 
 Sheets use conditional formatting: red for P0/P1, yellow for P2, no fill for P3.
 
-The HTML report's **Data-Room Completeness & Model Integrity** section surfaces
-the same request-list and formula-integrity views for browser-based review.
+For browser/PDF review the HTML report mirrors the analytical Excel sheets: the
+**Data-Room Completeness & Model Integrity** section surfaces the request-list,
+formula-integrity, and reference-files views; the **Contract Date Reconciliation**
+section shows active-vs-expired ARR; and the **Entity Resolution Log** (under
+Quality) shows how documents were matched to canonical entities.
+
+Spreadsheet formula-integrity issues (hardcoded overrides, circular refs,
+`#REF!`, broken links) are also minted as deterministic, citable Finance findings
+— so they appear in the findings table, severity rollups, and are answerable via
+`query`/`chat`, independent of whether an agent also flagged them.
 
 ## Generation Provenance & Cost
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dd-agents"
-version = "1.15.0"
+version = "1.16.0"
 description = "Open-source forensic M&A due diligence — 13 AI agents read your data room across 9 domains, cross-reference findings no single reviewer connects, and cite every one to an exact quote"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/dd_agents/extraction/formula_audit.py
+++ b/src/dd_agents/extraction/formula_audit.py
@@ -22,6 +22,7 @@ Contract:
 
 from __future__ import annotations
 
+import hashlib
 import re
 from collections import defaultdict
 from dataclasses import dataclass
@@ -364,8 +365,13 @@ def formula_findings(
         location = f"{sheet}!{cell}" if sheet else cell
         file_path = str(row.get("file", ""))
         detail = str(row.get("detail", ""))
-        # Stable, content-derived id so re-runs are idempotent (no clock/random).
-        seq = abs(hash((file_path, location, kind))) % 1_000_000
+        # Stable, content-derived id so re-runs are idempotent. Uses a SHA-256
+        # digest (NOT the builtin hash(), which is PYTHONHASHSEED-salted per
+        # process and would mint a different id each run — breaking cross-run
+        # finding-id references like chat corrections + the knowledge graph).
+        # Mirrors the tamper-finding id derivation in reporting/merge.py.
+        stable_key = f"{file_path}|{location}|{kind}"
+        seq = int(hashlib.sha256(stable_key.encode("utf-8")).hexdigest()[:8], 16) % 1_000_000
         # The Finding id pattern requires the subject segment to start with
         # [a-z0-9]; the synthetic safe name is "_model_integrity", so strip
         # leading underscores for the id only (the subject_safe_name key keeps it).

--- a/src/dd_agents/extraction/formula_audit.py
+++ b/src/dd_agents/extraction/formula_audit.py
@@ -309,6 +309,116 @@ def audit_data_room(
     )
 
 
+# Map each detector ``kind`` to a finding severity (Issue #245). Hardcoded
+# overrides, circular refs, and surfaced error literals materially move a
+# valuation model → P2; a broken external link is a quieter hygiene issue → P3.
+_KIND_SEVERITY: dict[str, str] = {
+    "hardcoded_override": "P2",
+    "circular_reference": "P2",
+    "error_literal": "P2",
+    "broken_external_link": "P3",
+}
+
+# Human-readable category per kind (stable machine-ish slug used by report
+# grouping + severity recalibration text matching).
+_KIND_CATEGORY: dict[str, str] = {
+    "hardcoded_override": "model_integrity_hardcoded_override",
+    "circular_reference": "model_integrity_circular_reference",
+    "error_literal": "model_integrity_error_literal",
+    "broken_external_link": "model_integrity_broken_link",
+}
+
+
+def formula_findings(
+    report: FormulaAuditReport,
+    *,
+    run_id: str,
+    subject: str,
+    subject_safe_name: str,
+    timestamp: str,
+) -> list[dict[str, str | dict[str, object] | list[object]]]:
+    """Convert a data-room formula audit into merged-finding dicts (Issue #245).
+
+    Each detected integrity issue becomes a standard finding dict (the same shape
+    specialist findings take in ``findings/merged/*.json``) so it reaches the
+    findings index, ``query``/``chat``, severity rollups, and the executive
+    summary — not only the report's Model-Integrity section.
+
+    Deterministic + parity-safe: an empty/clean report yields ``[]``. The finding
+    is attributed to the Finance agent (model integrity is a finance concern) and
+    routed to *subject_safe_name*. Severity is stamped with
+    ``metadata.provenance.severity_source = "formula_auditor"`` so the single
+    severity authority (``resolve_severity``) and the read-only recalibration
+    guard treat it as already-resolved (Design Rule 12) and never re-derive it.
+
+    Caller supplies ``run_id`` / ``timestamp`` (the module never reads the clock).
+    The citation ``source_path`` is the data-room-relative file path already on
+    each issue row; ``location`` is ``Sheet!Cell`` for exact grounding.
+    """
+    findings: list[dict[str, str | dict[str, object] | list[object]]] = []
+    for idx, row in enumerate(report["issues"]):
+        kind = str(row.get("kind", ""))
+        severity = _KIND_SEVERITY.get(kind, "P3")
+        sheet = str(row.get("sheet", ""))
+        cell = str(row.get("cell", ""))
+        location = f"{sheet}!{cell}" if sheet else cell
+        file_path = str(row.get("file", ""))
+        detail = str(row.get("detail", ""))
+        # Stable, content-derived id so re-runs are idempotent (no clock/random).
+        seq = abs(hash((file_path, location, kind))) % 1_000_000
+        # The Finding id pattern requires the subject segment to start with
+        # [a-z0-9]; the synthetic safe name is "_model_integrity", so strip
+        # leading underscores for the id only (the subject_safe_name key keeps it).
+        id_subject = subject_safe_name.lstrip("_") or "model_integrity"
+        findings.append(
+            {
+                "id": f"forensic-dd_finance_{id_subject}_{seq:06d}",
+                "severity": severity,
+                "category": _KIND_CATEGORY.get(kind, "model_integrity"),
+                "title": f"Spreadsheet model-integrity issue: {kind.replace('_', ' ')}"[:120],
+                "description": (
+                    f"Deterministic formula audit flagged a {kind.replace('_', ' ')} in "
+                    f"{file_path} at {location}. {detail}"
+                ),
+                "citations": [
+                    {
+                        "source_type": "file",
+                        "source_path": file_path,
+                        "location": location,
+                        "exact_quote": detail or None,
+                        "verification_status": "verified",
+                    }
+                ],
+                "confidence": "high",
+                "agent": "finance",
+                "skill": "forensic-dd",
+                "run_id": run_id,
+                "timestamp": timestamp,
+                "analysis_unit": subject,
+                "metadata": {
+                    "formula_audit": True,
+                    "detector": "audit_formulas",
+                    "kind": kind,
+                    "provenance": {
+                        "agent_name": "finance",
+                        "merge_action": "formula_audit_injected",
+                        "citation_verified": True,
+                        "severity_source": "formula_auditor",
+                        "severity_chain": [
+                            {
+                                "stage": "formula_auditor",
+                                "severity": severity,
+                                "reason": f"deterministic {kind} detection",
+                            }
+                        ],
+                    },
+                    "_idx": idx,
+                },
+            }
+        )
+    return findings
+
+
 def format_formula_audit(formula_map: FormulaMap, issues: list[FormulaIssue], *, max_issues: int = 40) -> str:
     """Render a compact markdown section for the agent prompt.
 

--- a/src/dd_agents/extraction/pipeline.py
+++ b/src/dd_agents/extraction/pipeline.py
@@ -164,6 +164,14 @@ class ExtractionPipeline:
         self._markitdown = markitdown or MarkitdownExtractor()
         self._ocr = ocr or OCRExtractor()
         self._glm_ocr = glm_ocr
+        # Claude-vision LLM usage accumulator (Issue #247). The vision fallback is
+        # a real reasoning call through the seam; its token spend must reach the
+        # run's CostTracker / per-provider audit receipt / budget gate. Thread-safe
+        # because extract_all runs vision calls from worker threads.
+        self._vision_usage_lock = threading.Lock()
+        self._vision_input_tokens = 0
+        self._vision_output_tokens = 0
+        self._vision_calls = 0
 
     # ------------------------------------------------------------------
     # Public API
@@ -1611,11 +1619,12 @@ class ExtractionPipeline:
     # Claude vision last-resort (Issue #27)
     # ------------------------------------------------------------------
 
-    @staticmethod
-    async def _describe_image_async(filepath: Path) -> str:
+    async def _describe_image_async(self, filepath: Path) -> str:
         """Use Claude Agent SDK to visually describe an image or PDF.
 
-        Returns a text description or empty string on failure.
+        Returns a text description or empty string on failure. Token usage from
+        the ``ResultMessage`` is accumulated (Issue #247) so the run's CostTracker
+        can attribute and budget-gate this LLM spend.
         """
         from claude_agent_sdk import (
             AssistantMessage,
@@ -1657,17 +1666,48 @@ class ExtractionPipeline:
                     for block in message.content:
                         if isinstance(block, TextBlock):
                             text_parts.append(block.text)
-                elif isinstance(message, ResultMessage) and message.is_error:
-                    logger.debug("Claude vision error for %s: %s", filepath, message.result)
-                    return ""
+                elif isinstance(message, ResultMessage):
+                    # Accumulate token usage whether or not the call errored —
+                    # an errored vision call still consumed input tokens (#247).
+                    self._record_vision_usage(getattr(message, "usage", None))
+                    if message.is_error:
+                        logger.debug("Claude vision error for %s: %s", filepath, message.result)
+                        return ""
         except Exception as exc:
             logger.debug("Claude vision failed for %s: %s", filepath, exc)
             return ""
 
         return "\n".join(text_parts)
 
-    @staticmethod
-    def _try_claude_vision(filepath: Path) -> tuple[str, float]:
+    def _record_vision_usage(self, usage: Any) -> None:
+        """Accumulate input/output tokens from a vision ``ResultMessage.usage`` (#247).
+
+        ``usage`` is the SDK usage object/dict (``input_tokens``/``output_tokens``)
+        or None. Thread-safe; tolerant of missing/oddly-shaped usage (best-effort).
+        """
+        if usage is None:
+            return
+
+        def _field(name: str) -> int:
+            val = usage.get(name) if isinstance(usage, dict) else getattr(usage, name, 0)
+            try:
+                return int(val or 0)
+            except (TypeError, ValueError):
+                return 0
+
+        with self._vision_usage_lock:
+            self._vision_input_tokens += _field("input_tokens")
+            self._vision_output_tokens += _field("output_tokens")
+            self._vision_calls += 1
+
+    def vision_usage(self) -> tuple[int, int, int]:
+        """Return ``(input_tokens, output_tokens, calls)`` accumulated across the
+        run's Claude-vision fallback calls (Issue #247). ``(0, 0, 0)`` when the
+        fallback never fired — the engine records nothing in that case (parity)."""
+        with self._vision_usage_lock:
+            return (self._vision_input_tokens, self._vision_output_tokens, self._vision_calls)
+
+    def _try_claude_vision(self, filepath: Path) -> tuple[str, float]:
         """Synchronous wrapper for :meth:`_describe_image_async`.
 
         The pipeline is synchronous but may be called from within a
@@ -1680,7 +1720,7 @@ class ExtractionPipeline:
         from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
 
         def _run() -> str:
-            return _asyncio.run(ExtractionPipeline._describe_image_async(filepath))
+            return _asyncio.run(self._describe_image_async(filepath))
 
         try:
             with _ThreadPoolExecutor(max_workers=1) as pool:

--- a/src/dd_agents/orchestrator/engine.py
+++ b/src/dd_agents/orchestrator/engine.py
@@ -957,8 +957,42 @@ class PipelineEngine:
         except ExtractionPipelineError as exc:
             raise BlockingGateError(f"Extraction failed: {exc}") from exc
 
+        # Account for any Claude-vision fallback LLM spend in the run's cost
+        # tracker / per-provider audit receipt / budget gate (Issue #247). No-op
+        # when the vision fallback never fired (parity).
+        self._record_vision_cost(pipeline)
+
         logger.info("Extraction complete for %d files", len(file_paths))
         return state
+
+    def _record_vision_cost(self, pipeline: Any) -> None:
+        """Record Claude-vision extraction token spend in the CostTracker (#247).
+
+        The vision fallback is a real reasoning call through the seam; its tokens
+        must reach ``cost_summary.json`` (by_model/by_provider/total) and the
+        budget gate. Attributed to ``extraction_vision`` with the resolved
+        provider/base_url (secret-free). No-op when no vision call fired.
+        """
+        getter = getattr(pipeline, "vision_usage", None)
+        if not callable(getter):
+            return
+        input_tokens, output_tokens, calls = getter()
+        if calls <= 0:
+            return
+        import os
+
+        from dd_agents.llm import resolve_provider
+
+        info = resolve_provider()
+        self.cost_tracker.record(
+            agent_name="extraction_vision",
+            step="05_bulk_extraction",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            model=os.getenv("DD_VISION_MODEL", "") or "",
+            provider=info.provider,
+            base_url=info.safe_base_url,
+        )
 
     # Phase 3: Inventory ----------------------------------------------------
 
@@ -1076,6 +1110,10 @@ class PipelineEngine:
                 if isinstance(file_val, str):
                     row["file"] = file_val.removeprefix(base)
             (inv_dir / "formula_audit.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+            # Stash the audit so formula-integrity issues become first-class
+            # findings in the findings index (query/chat/severity/exec summary),
+            # not only the report's Model-Integrity section (Issue #245).
+            state._formula_audit_report = report  # type: ignore[attr-defined]
             logger.info(
                 "Formula audit: %d file(s) with formulas, %d issue(s)",
                 report["files_with_formulas"],
@@ -1083,6 +1121,30 @@ class PipelineEngine:
             )
         except Exception as exc:  # noqa: BLE001 — advisory; never block the run
             logger.debug("Formula audit skipped: %s", exc)
+
+    def _formula_audit_for_merge(self, state: PipelineState) -> dict[str, Any] | None:
+        """Return the formula-audit report for merge-time injection (Issue #245).
+
+        The audit ran in step 06 and stashed its report on ``state``; on
+        ``--resume`` (when the stash is gone) it falls back to the persisted
+        ``inventory/formula_audit.json``. Returns the report (or None) so the merge
+        step can mint deterministic model-integrity findings that persist to
+        ``findings/merged/`` — reaching the findings index (query/chat), counts
+        (step 29), audit (step 30), and the report.
+        """
+        report = getattr(state, "_formula_audit_report", None)
+        if isinstance(report, dict) and report.get("issues"):
+            return report
+        # Resume fallback: re-read the persisted artifact.
+        fa_path = self._inventory_dir(state) / "formula_audit.json"
+        if fa_path.exists():
+            try:
+                loaded = json.loads(fa_path.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict) and loaded.get("issues"):
+                    return loaded
+            except (json.JSONDecodeError, OSError):
+                return None
+        return None
 
     def _per_agent_routes(self, state: PipelineState) -> dict[str, dict[str, str]]:
         """Secret-free per-agent routing receipt for the report (Issue #240).
@@ -3255,6 +3317,16 @@ class PipelineEngine:
         if tamper_count:
             logger.warning("Injected %d deterministic document_integrity (tamper) finding(s)", tamper_count)
 
+        # Deterministic formula-integrity findings (Issue #245). The audit ran in
+        # step 06; mint findings here — BEFORE write_merged — so they persist to
+        # findings/merged/, are counted (step 29), audited (step 30), and reach
+        # the findings index (query/chat) + report. Idempotent + parity-safe.
+        formula_report = self._formula_audit_for_merge(state)
+        if formula_report is not None:
+            formula_count = merger.inject_formula_findings(merged, formula_report)
+            if formula_count:
+                logger.info("Injected %d deterministic model-integrity (formula) finding(s)", formula_count)
+
         # Write merged files
         merged_dir = findings_dir / "merged"
         merger.write_merged(merged, merged_dir)
@@ -3758,6 +3830,10 @@ class PipelineEngine:
         # standard Gap records into the report so they surface in the gaps
         # section (not just the inventory JSON). No-op when no request list.
         self._inject_request_list_gaps(state, merged_findings)
+        # NOTE: formula-integrity findings (Issue #245) are injected at the MERGE
+        # step (27), persisted to findings/merged/_model_integrity.json, so they
+        # reach the findings index (query/chat), counts (29), audit (30), AND the
+        # report — not only this in-memory report view. See merge.inject_formula_findings.
 
         # ------------------------------------------------------------------
         # Schema resolution with config/ fallback (Issue #35)

--- a/src/dd_agents/orchestrator/engine.py
+++ b/src/dd_agents/orchestrator/engine.py
@@ -3781,7 +3781,11 @@ class PipelineEngine:
 
         run_metadata["finding_counts"] = {**sev_counts, "total": total_findings}
         run_metadata["gap_counts"] = {"total": total_gaps}
-        run_metadata["subject_count"] = len(merged_findings)
+        # Count real entities only — synthetic deal-wide subjects (_request_list,
+        # _model_integrity) carry findings but are not entities (Issues #192/#245).
+        from dd_agents.utils.constants import is_synthetic_subject
+
+        run_metadata["subject_count"] = sum(1 for csn in merged_findings if not is_synthetic_subject(str(csn)))
         run_metadata["reference_file_count"] = len(run_metadata.get("reference_files", []))
 
         # Numerical manifest entries (N001–N00x) for cross-format parity.
@@ -3814,6 +3818,7 @@ class PipelineEngine:
         """
         from dd_agents.models.reporting import ReportSchema
         from dd_agents.reporting.excel import ExcelReportGenerator
+        from dd_agents.utils.constants import is_synthetic_subject as _is_synth
 
         # Load merged findings
         merged_dir = state.run_dir / "findings" / "merged"
@@ -3948,6 +3953,11 @@ class PipelineEngine:
             # severity distribution that appears in the final reports.
             from dd_agents.reporting.computed_metrics import ReportDataComputer
 
+            # Real-entity count for the synthesis LLM input — exclude synthetic
+            # deal-wide subjects (_request_list, _model_integrity) so the model
+            # isn't told there are more entities than the deal has (Issues #192/#245).
+            es_entity_count = sum(1 for csn in merged_findings if not _is_synth(str(csn)))
+
             p0_findings: list[dict[str, Any]] = []
             p1_findings: list[dict[str, Any]] = []
             severity_dist: dict[str, int] = _sev_count_init()
@@ -3980,7 +3990,7 @@ class PipelineEngine:
                 "Executive synthesis input: %d P0, %d P1 findings across %d entities",
                 len(p0_findings),
                 len(p1_findings),
-                len(merged_findings),
+                es_entity_count,
             )
 
             deal_config_for_es = state.deal_config if isinstance(state.deal_config, dict) else None
@@ -3989,7 +3999,7 @@ class PipelineEngine:
                 "p0_findings": p0_findings,
                 "p1_findings": p1_findings,
                 "findings_summary": {
-                    "total_subjects": len(merged_findings),
+                    "total_subjects": sum(1 for _csn in merged_findings if not _is_synth(str(_csn))),
                     "total_findings": sum(
                         len(v.get("findings", [])) for v in merged_findings.values() if isinstance(v, dict)
                     ),
@@ -4044,7 +4054,7 @@ class PipelineEngine:
                 ai_state = {
                     "buyer_strategy": deal_config_dict["buyer_strategy"],
                     "merged_findings_summary": {
-                        "total_subjects": len(merged_findings),
+                        "total_subjects": sum(1 for _csn in merged_findings if not _is_synth(str(_csn))),
                         "total_findings": sum(
                             len(v.get("findings", [])) for v in merged_findings.values() if isinstance(v, dict)
                         ),
@@ -4149,7 +4159,7 @@ class PipelineEngine:
                     "p0_findings": p0_findings,
                     "p1_findings": p1_findings,
                     "findings_summary": {
-                        "total_subjects": len(merged_findings),
+                        "total_subjects": sum(1 for _csn in merged_findings if not _is_synth(str(_csn))),
                         "total_findings": sum(
                             len(v.get("findings", [])) for v in merged_findings.values() if isinstance(v, dict)
                         ),

--- a/src/dd_agents/reporting/computed_metrics.py
+++ b/src/dd_agents/reporting/computed_metrics.py
@@ -33,6 +33,7 @@ from dd_agents.utils.constants import (
     SEVERITY_RISK_SCORE_WEIGHTS,
     SEVERITY_WEIGHTS,
     _sev_count_init,
+    is_synthetic_subject,
 )
 
 logger = logging.getLogger(__name__)
@@ -1392,6 +1393,12 @@ class ReportDataComputer:
 
         # --- Issue #113: Topic classification, health tiers, recommendations ---
         topic_findings = self._classify_by_topic(all_findings)
+        # Real-entity count: exclude synthetic deal-wide subjects (_request_list,
+        # _model_integrity) so per-entity denominators + the "Entities Analyzed"
+        # headline reflect actual entities, not auto-generated finding buckets
+        # (Issues #192/#245). Their findings/gaps still count in totals above.
+        entity_count = sum(1 for csn in merged_data if not is_synthetic_subject(str(csn)))
+
         extracted_amounts, total_arr = self._extract_financials(all_findings)
         tier1, tier2, tier3 = self._compute_health_tiers(subject_risk_raw, merged_data)
         subject_p0_summary, subject_p1_summary = self._build_subject_severity_tables(merged_data, subject_risk_raw)
@@ -1402,7 +1409,7 @@ class ReportDataComputer:
             total_findings,
             governance_scores,
             concentration_hhi,
-            len(merged_data),
+            entity_count,
         )
         section_rag = self._compute_section_rag(
             severity_counts,
@@ -1423,7 +1430,7 @@ class ReportDataComputer:
         total_risk_exposure = sum(revenue_by_subject.get(csn, 0.0) for csn in all_at_risk_csns)
         risk_adjusted_arr = max(0.0, total_contracted_arr - total_risk_exposure)
         subjects_with_revenue = len(revenue_by_subject)
-        revenue_data_coverage = subjects_with_revenue / len(merged_data) if merged_data else 0.0
+        revenue_data_coverage = subjects_with_revenue / entity_count if entity_count else 0.0
         concentration_treemap = self._build_concentration_treemap(
             revenue_by_subject,
             subject_risk_raw,
@@ -1581,7 +1588,7 @@ class ReportDataComputer:
             material_by_severity,
             domain_summaries_data,
             total_risk_exposure,
-            len(merged_data),
+            entity_count,
         )
 
         # --- Issue #200: Actionable recommendations (template-matched) ---
@@ -1605,8 +1612,8 @@ class ReportDataComputer:
         return ReportComputedData(
             total_findings=total_findings,
             total_gaps=total_gaps,
-            total_subjects=len(merged_data),
-            subjects_analyzed=len(merged_data),
+            total_subjects=entity_count,
+            subjects_analyzed=entity_count,
             findings_by_severity=severity_counts,
             findings_by_domain=dict(domain_findings_count),
             findings_by_category={k: v for k, v in findings_by_category.items()},

--- a/src/dd_agents/reporting/html.py
+++ b/src/dd_agents/reporting/html.py
@@ -35,6 +35,7 @@ from dd_agents.reporting.html_base import render_css, render_js, render_nav_bar
 from dd_agents.reporting.html_completeness import CompletenessRenderer
 from dd_agents.reporting.html_compliance import ComplianceRenderer
 from dd_agents.reporting.html_config_panel import ConfigPanelRenderer
+from dd_agents.reporting.html_contract_dates import ContractDatesRenderer
 from dd_agents.reporting.html_cross import CrossRefRenderer
 from dd_agents.reporting.html_cross_domain import CrossDomainRenderer
 from dd_agents.reporting.html_dashboard import DashboardRenderer
@@ -279,6 +280,7 @@ class HTMLReportGenerator:
             IntegrationPlaybookRenderer(computed, merged_data, renderer_config),
             GovernanceGraphRenderer(computed, merged_data, renderer_config),
             GapRenderer(computed, merged_data, renderer_config),
+            ContractDatesRenderer(computed, merged_data, renderer_config),
             CompletenessRenderer(computed, merged_data, renderer_config),
             SubjectRenderer(computed, merged_data, renderer_config),
             ConfigPanelRenderer(computed, merged_data, renderer_config),

--- a/src/dd_agents/reporting/html_base.py
+++ b/src/dd_agents/reporting/html_base.py
@@ -1348,6 +1348,7 @@ def render_nav_bar(section_rag: dict[str, str] | None = None) -> str:
         "<div class='toc-group-label'>Evidence</div>"
         "<a href='#sec-subjects'>Entity Detail</a>"
         f"<a href='#sec-gaps'>{_rag('gaps')} Data Gaps</a>"
+        "<a href='#sec-contract-dates'>Contract Dates</a>"
         "<a href='#sec-completeness'>Completeness</a>"
         "<a href='#sec-methodology'>Methodology</a>"
         "</div>"

--- a/src/dd_agents/reporting/html_completeness.py
+++ b/src/dd_agents/reporting/html_completeness.py
@@ -41,12 +41,15 @@ class CompletenessRenderer(SectionRenderer):
             return ""
         request_list = run_meta.get("request_list")
         formula_audit = run_meta.get("formula_audit")
+        reference_files = run_meta.get("reference_files")
 
         body: list[str] = []
         if isinstance(request_list, dict) and request_list:
             body.append(self._render_request_list(request_list))
         if isinstance(formula_audit, dict) and formula_audit.get("files_with_formulas"):
             body.append(self._render_formula_audit(formula_audit))
+        if isinstance(reference_files, list) and reference_files:
+            body.append(self._render_reference_files(reference_files))
 
         body = [b for b in body if b]
         if not body:
@@ -168,4 +171,36 @@ class CompletenessRenderer(SectionRenderer):
         if truncated:
             parts.append("<p class='text-muted'>Note: issue list truncated to a bounded cap.</p>")
         parts.append("</div></div>")
+        return "".join(parts)
+
+    # -- Reference-files disclosure (Issue #244) -----------------------------
+
+    def _render_reference_files(self, files: list[Any]) -> str:
+        """Disclose reference-only documents that were deliberately NOT routed to
+        any specialist (per the DD_OUTPUT rule) — a transparency note so an HTML
+        reviewer can see which data-room files were treated as reference-only.
+        Surfaced in Excel (Reference_Files_Index); this adds the HTML counterpart.
+        """
+        rows = [f for f in files if isinstance(f, dict)]
+        if not rows:
+            return ""
+        parts: list[str] = [
+            "<div class='domain-section'>",
+            "<div class='domain-header' tabindex='0' role='button' aria-expanded='false'"
+            " style='border-left-color: var(--gray)'>",
+            f"<h2>Reference Files ({len(rows)})</h2>",
+            "<span class='arrow'>&#9654;</span></div>",
+            "<div class='domain-body'>",
+            "<p class='text-muted'>Reference-only documents (readout decks, internal analysis) classified as "
+            "context and intentionally not routed to a specialist agent — listed for inventory transparency.</p>",
+            "<table class='subject-table sortable'><caption>Reference files</caption>"
+            "<thead><tr><th scope='col'>File</th><th scope='col'>Category</th>"
+            "<th scope='col'>Description</th></tr></thead><tbody>",
+        ]
+        for row in rows:
+            file_path = self.escape(str(row.get("file_path", "")))
+            category = self.escape(str(row.get("category", "")))
+            description = self.escape(str(row.get("description", "")))
+            parts.append(f"<tr><td>{file_path}</td><td>{category}</td><td>{description}</td></tr>")
+        parts.append("</tbody></table></div></div>")
         return "".join(parts)

--- a/src/dd_agents/reporting/html_contract_dates.py
+++ b/src/dd_agents/reporting/html_contract_dates.py
@@ -1,0 +1,87 @@
+"""Contract-date reconciliation renderer (Issue #244).
+
+Surfaces the active-vs-expired ARR reconciliation in the HTML report (and thus
+the PDF, which renders the same HTML). The data is computed in pipeline step 11
+(``ContractDateReconciler``), persisted to ``contract_date_reconciliation.json``,
+and was previously surfaced ONLY in the Excel ``Contract_Date_Reconciliation``
+sheet — a primary-deliverable parity gap.
+
+Each entry compares the subject database's `end_date` against the date found in
+the contracts, with a status and the ARR a reviewer should **discount** (expired)
+or **re-credit** (stale DB). Sourced from the persisted run metadata (mirrors how
+``excel._data_contract_dates`` reads it). Parity-safe: renders nothing when no
+reconciliation entries exist.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dd_agents.reporting.html_base import SectionRenderer, fmt_currency
+
+
+class ContractDatesRenderer(SectionRenderer):
+    """Render the contract-date reconciliation section (active-vs-expired ARR)."""
+
+    def render(self) -> str:
+        run_meta = (self.config or {}).get("_run_metadata") or {}
+        if not isinstance(run_meta, dict):
+            return ""
+        recon = run_meta.get("contract_date_reconciliation")
+        if not isinstance(recon, dict):
+            return ""
+        entries = recon.get("entries")
+        if not isinstance(entries, list) or not entries:
+            return ""
+
+        parts: list[str] = [
+            "<section class='report-section' id='sec-contract-dates'>",
+            "<h2>Contract Date Reconciliation</h2>",
+        ]
+
+        # KPI line for the two dollar aggregates a reviewer acts on.
+        total_expired = _as_float(recon.get("total_expired_arr"))
+        total_reclassified = _as_float(recon.get("total_reclassified_arr"))
+        if total_expired or total_reclassified:
+            parts.append(
+                self.render_alert(
+                    "high" if total_expired else "info",
+                    "Revenue impact",
+                    f"Expired ARR (discount candidate): {fmt_currency(total_expired)} · "
+                    f"Reclassified ARR (stale database): {fmt_currency(total_reclassified)}.",
+                )
+            )
+
+        parts.append(
+            "<table class='subject-table sortable'><caption>Contract date reconciliation</caption>"
+            "<thead><tr><th scope='col'>Entity</th><th scope='col'>Status</th>"
+            "<th scope='col'>Database End</th><th scope='col'>Actual End</th>"
+            "<th scope='col'>ARR</th><th scope='col'>Evidence</th></tr></thead><tbody>"
+        )
+        for e in entries:
+            if not isinstance(e, dict):
+                continue
+            subject = self.escape(str(e.get("subject", "")))
+            status = self.escape(str(e.get("status", "")))
+            db_end = self.escape(str(e.get("database_end_date", "")))
+            actual_end = self.escape(str(e.get("actual_end_date", "")))
+            arr = fmt_currency(_as_float(e.get("arr")))
+            evidence = self.escape(str(e.get("evidence", "")))
+            ev_file = str(e.get("evidence_file", ""))
+            if ev_file:
+                evidence = f"{evidence} <span class='text-muted'>({self.escape(ev_file)})</span>"
+            parts.append(
+                f"<tr><td>{subject}</td><td>{status}</td><td>{db_end}</td>"
+                f"<td>{actual_end}</td><td>{arr}</td><td>{evidence}</td></tr>"
+            )
+        parts.append("</tbody></table>")
+        parts.append("</section>")
+        return "\n".join(parts)
+
+
+def _as_float(value: Any) -> float:
+    """Coerce a possibly-missing/str numeric to float; 0.0 on failure."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/src/dd_agents/reporting/html_quality.py
+++ b/src/dd_agents/reporting/html_quality.py
@@ -32,8 +32,48 @@ class QualityRenderer(SectionRenderer):
         parts: list[str] = []
         parts.append(self._render_governance_metrics())
         parts.append(self._render_quality_scores())
+        parts.append(self._render_entity_resolution())
         parts.append(self._render_audit_checks())
         return "\n".join(p for p in parts if p)
+
+    def _render_entity_resolution(self) -> str:
+        """Render the entity-resolution match log (Issue #244).
+
+        The match log (which distinctly-named documents were merged under one
+        canonical subject, and which candidates were rejected) is the provenance
+        for how per-entity finding counts and ARR roll up — previously surfaced
+        only in the Excel ``Entity_Resolution_Log`` sheet. Sourced from the same
+        ``run_metadata['entity_matches']`` list ``excel._data_entity_log`` reads.
+        Parity-safe: renders nothing when there are no matches.
+        """
+        run_metadata = self.config.get("_run_metadata")
+        if not isinstance(run_metadata, dict):
+            return ""
+        matches = run_metadata.get("entity_matches")
+        if not isinstance(matches, list) or not matches:
+            return ""
+
+        parts: list[str] = [
+            "<section class='report-section' id='sec-entity-resolution'>",
+            "<h2>Entity Resolution Log</h2>",
+            "<p class='text-muted'>How distinctly-named documents were matched to a canonical entity. "
+            "This is the provenance behind per-entity finding counts and ARR rollups.</p>",
+            "<table class='sortable'><caption>Entity resolution matches</caption><thead><tr>"
+            "<th scope='col'>Source Name</th><th scope='col'>Matched To (Canonical)</th>"
+            "<th scope='col'>Method</th><th scope='col'>Confidence</th></tr></thead><tbody>",
+        ]
+        for m in matches:
+            if not isinstance(m, dict):
+                continue
+            source = self.escape(str(m.get("source_name", "")))
+            canonical = self.escape(str(m.get("canonical_name", m.get("matched_name", ""))))
+            method = self.escape(str(m.get("match_method", "")))
+            conf = m.get("confidence", "")
+            conf_str = self.escape(f"{conf:.0%}" if isinstance(conf, (int, float)) else str(conf))
+            parts.append(f"<tr><td>{source}</td><td>{canonical}</td><td>{method}</td><td>{conf_str}</td></tr>")
+        parts.append("</tbody></table>")
+        parts.append("</section>")
+        return "\n".join(parts)
 
     def _render_governance_metrics(self) -> str:
         scores: list[tuple[str, float]] = []

--- a/src/dd_agents/reporting/html_subjects.py
+++ b/src/dd_agents/reporting/html_subjects.py
@@ -13,7 +13,7 @@ from dd_agents.reporting.html_base import (
     SEVERITY_COLORS,
     SectionRenderer,
 )
-from dd_agents.utils.constants import SEVERITY_P3
+from dd_agents.utils.constants import SEVERITY_P3, is_synthetic_subject
 
 
 class SubjectRenderer(SectionRenderer):
@@ -25,6 +25,11 @@ class SubjectRenderer(SectionRenderer):
             "<h2>Entity Detail</h2>",
         ]
         for csn, data in sorted(self.merged_data.items()):
+            # Skip synthetic deal-wide subjects (_request_list, _model_integrity):
+            # they carry auto-generated findings/gaps but are not real entities,
+            # so they must not render as an Entity Detail card (Issues #192/#245).
+            if is_synthetic_subject(str(csn)):
+                continue
             parts.append(self._render_subject_section(csn, data))
         parts.append("</section>")
         return "\n".join(parts)

--- a/src/dd_agents/reporting/merge.py
+++ b/src/dd_agents/reporting/merge.py
@@ -1917,6 +1917,70 @@ class FindingMerger:
             )
         return added
 
+    # Synthetic subject key for deterministic model-integrity findings (Issue #245).
+    _FORMULA_SUBJECT = "Financial models"
+    _FORMULA_SAFE_NAME = "_model_integrity"
+
+    def inject_formula_findings(
+        self,
+        merged: dict[str, MergedSubjectOutput],
+        formula_report: dict[str, Any],
+    ) -> int:
+        """Mint deterministic spreadsheet model-integrity findings (Issue #245).
+
+        The formula audit (``extraction/formula_audit.audit_data_room``, run in
+        pipeline step 06) detects hardcoded overrides, circular refs, ``#REF!``,
+        and broken external links citing an exact ``Sheet!Cell``. v1.15.0 surfaced
+        these only in the report's Model-Integrity section; this routes each into a
+        first-class :class:`Finding` (Finance agent) on a synthetic
+        ``_model_integrity`` subject so they ALSO reach the findings index
+        (query/chat), the numerical manifest (step 29), the audit (step 30), and
+        severity rollups.
+
+        Mutating but idempotent: each finding's id is content-derived
+        (``file``/``Sheet!Cell``/``kind``) — independent of ``run_id`` — so
+        ``--resume`` never duplicates. Severity is stamped with
+        ``metadata.provenance.severity_source = "formula_auditor"`` so the single
+        severity authority (:func:`resolve_severity`) and the read-only
+        recalibration guard treat it as already-resolved (Design Rule 12). Returns
+        the count of findings newly added. No-op (returns 0) for an empty report.
+        """
+        from dd_agents.extraction.formula_audit import formula_findings
+
+        raw_findings = formula_findings(
+            formula_report,  # type: ignore[arg-type]
+            run_id=self.run_id,
+            subject=self._FORMULA_SUBJECT,
+            subject_safe_name=self._FORMULA_SAFE_NAME,
+            timestamp=self.timestamp,
+        )
+        if not raw_findings:
+            return 0
+
+        mco = merged.get(self._FORMULA_SAFE_NAME)
+        if mco is None:
+            mco = MergedSubjectOutput(
+                subject=self._FORMULA_SUBJECT,
+                subject_safe_name=self._FORMULA_SAFE_NAME,
+            )
+            merged[self._FORMULA_SAFE_NAME] = mco
+
+        existing_ids = {f.id for f in mco.findings}
+        added = 0
+        for raw in raw_findings:
+            fid = str(raw["id"])
+            if fid in existing_ids:  # idempotent under --resume
+                continue
+            try:
+                finding = Finding.model_validate(raw)
+            except Exception:  # noqa: BLE001 — never let one bad row break merge
+                logger.exception("Failed to build formula-integrity finding %s", fid)
+                continue
+            mco.findings.append(finding)
+            existing_ids.add(fid)
+            added += 1
+        return added
+
     @staticmethod
     def _first_real_citation(mco: MergedSubjectOutput, source_finding_id: Any) -> tuple[str, str]:
         """Return ``(source_path, exact_quote)`` of the first real citation on the

--- a/src/dd_agents/utils/constants.py
+++ b/src/dd_agents/utils/constants.py
@@ -184,6 +184,27 @@ NON_SUBJECT_STEMS: frozenset[str] = frozenset(
     }
 )
 
+# Synthetic, deal-wide subject keys that carry auto-generated findings/gaps but
+# are NOT real entities (Issues #192/#245). Their findings/gaps still count in
+# totals + reach the findings index, but they must be EXCLUDED from per-entity
+# denominators (entity count, revenue coverage, HHI) and the Entity Detail
+# section — otherwise a 4-entity deal reports 5 "Entities Analyzed". Any merged
+# subject key in this set (or, defensively, starting with "_") is synthetic.
+SYNTHETIC_SUBJECT_KEYS: frozenset[str] = frozenset(
+    {
+        "_request_list",
+        "_model_integrity",
+    }
+)
+
+
+def is_synthetic_subject(subject_safe_name: str) -> bool:
+    """True when *subject_safe_name* is a synthetic deal-wide subject, not a real
+    entity (see :data:`SYNTHETIC_SUBJECT_KEYS`). Leading-underscore keys are
+    treated as synthetic defensively."""
+    return subject_safe_name in SYNTHETIC_SUBJECT_KEYS or subject_safe_name.startswith("_")
+
+
 # ---------------------------------------------------------------------------
 # Severity scoring weights (used for sorting and risk scoring)
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_v115_features.py
+++ b/tests/integration/test_v115_features.py
@@ -166,3 +166,44 @@ class TestICMemoLanguagePassthrough:
         memo = render_ic_memo(computed, {"buyer": {"name": "B"}, "target": {"name": "TargetCo"}})
         # The non-English finding text appears unchanged — no translation pass.
         assert french_title in memo
+
+
+class TestFormulaFindingsReachQueryIndex:
+    """#245: injected formula-integrity findings flow merge → disk → query index."""
+
+    def test_merged_formula_findings_are_indexed(self, tmp_path: Path) -> None:
+        from dd_agents.query.indexer import FindingIndexer
+        from dd_agents.reporting.merge import FindingMerger
+
+        report = {
+            "files_scanned": 1,
+            "files_with_formulas": 1,
+            "files_with_issues": 1,
+            "total_issues": 1,
+            "by_kind": {"hardcoded_override": 1},
+            "issues": [
+                {
+                    "file": "Acme/model.xlsx",
+                    "sheet": "P&L",
+                    "cell": "B5",
+                    "kind": "hardcoded_override",
+                    "detail": "Hardcoded value 1234 in column B",
+                }
+            ],
+            "truncated": False,
+        }
+        merger = FindingMerger(run_id="r1", config_hash="h", prompt_version="1.0.0")
+        merged: dict = {}
+        added = merger.inject_formula_findings(merged, report)
+        assert added == 1
+
+        # Persist to findings/merged/ exactly as the pipeline does.
+        merged_dir = tmp_path / "findings" / "merged"
+        merger.write_merged(merged, merged_dir)
+        assert (merged_dir / "_model_integrity.json").exists()
+
+        # The query indexer reads findings/merged/*.json from disk.
+        index = FindingIndexer().index_report(tmp_path)
+        titles = " ".join(f.get("title", "") for f in index.findings).lower()
+        assert "model-integrity" in titles or "hardcoded" in titles
+        assert index.total_findings >= 1

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -1876,7 +1876,9 @@ class TestClaudeVision:
             "_describe_image_async",
             side_effect=TimeoutError("timed out"),
         ):
-            text, conf = ExtractionPipeline._try_claude_vision(filepath)
+            # _try_claude_vision is now an instance method (Issue #247: it
+            # accumulates per-instance vision token usage).
+            text, conf = ExtractionPipeline()._try_claude_vision(filepath)
 
         assert text == ""
         assert conf == 0.0

--- a/tests/unit/test_formula_findings.py
+++ b/tests/unit/test_formula_findings.py
@@ -118,3 +118,58 @@ class TestInjectFormulaFindings:
         raw = merged["_model_integrity"].findings[0].model_dump()
         out = ReportDataComputer._recalibrate_severity(raw)
         assert out["severity"] == "P2"  # unchanged by the read-only guard
+
+
+class TestSyntheticSubjectExclusion:
+    """_model_integrity must NOT inflate entity counts (audit fix, Issue #245)."""
+
+    def test_entity_count_excludes_synthetic_subjects(self) -> None:
+        from dd_agents.reporting.computed_metrics import ReportDataComputer
+
+        merged = {
+            "acme_corp": {"subject": "Acme Corp", "findings": [], "gaps": []},
+            "globex": {"subject": "Globex", "findings": [], "gaps": []},
+            "_model_integrity": {"subject": "Financial models", "findings": [], "gaps": []},
+            "_request_list": {"subject": "Deal-wide", "findings": [], "gaps": []},
+        }
+        computed = ReportDataComputer().compute(merged)
+        # 2 real entities, not 4.
+        assert computed.total_subjects == 2
+        assert computed.subjects_analyzed == 2
+
+    def test_entity_detail_skips_synthetic_subject(self) -> None:
+        from dd_agents.reporting.computed_metrics import ReportDataComputer
+        from dd_agents.reporting.html_subjects import SubjectRenderer
+
+        merged = {
+            "acme_corp": {"subject": "Acme Corp", "findings": [], "gaps": []},
+            "_model_integrity": {"subject": "Financial models", "findings": [], "gaps": []},
+        }
+        computed = ReportDataComputer().compute(merged)
+        html = SubjectRenderer(computed, merged, {}).render()
+        assert "Acme Corp" in html
+        assert "Financial models" not in html
+
+
+class TestFindingIdStableAcrossProcesses:
+    """Finding ids must be content-stable across processes (audit fix, Issue #245)."""
+
+    def test_id_matches_known_digest_independent_of_hashseed(self) -> None:
+        import os
+        import subprocess
+        import sys
+
+        code = (
+            "from dd_agents.extraction.formula_audit import formula_findings;"
+            "r={'files_scanned':1,'files_with_formulas':1,'files_with_issues':1,'total_issues':1,"
+            "'by_kind':{},'issues':[{'file':'a.xlsx','sheet':'S','cell':'B7','kind':'error_literal','detail':'d'}],"
+            "'truncated':False};"
+            "print(formula_findings(r,run_id='r',subject='S',subject_safe_name='_m',timestamp='t')[0]['id'])"
+        )
+        ids = set()
+        for seed in ("0", "1", "12345"):
+            env = {**os.environ, "PYTHONHASHSEED": seed}
+            out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env, check=True)
+            ids.add(out.stdout.strip())
+        # Same content → same id regardless of hash seed (no builtin hash()).
+        assert len(ids) == 1

--- a/tests/unit/test_formula_findings.py
+++ b/tests/unit/test_formula_findings.py
@@ -1,0 +1,120 @@
+"""Tests for routing formula-integrity issues into the findings index (Issue #245).
+
+Covers the pure `formula_findings()` builder and the merger's
+`inject_formula_findings()` (idempotent, parity-safe, severity pre-resolved).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dd_agents.extraction.formula_audit import formula_findings
+from dd_agents.models.finding import Finding, MergedSubjectOutput
+from dd_agents.reporting.merge import FindingMerger
+
+
+def _report(issues: list[dict[str, str]]) -> dict[str, Any]:
+    return {
+        "files_scanned": 1,
+        "files_with_formulas": 1,
+        "files_with_issues": 1 if issues else 0,
+        "total_issues": len(issues),
+        "by_kind": {},
+        "issues": issues,
+        "truncated": False,
+    }
+
+
+_ISSUES = [
+    {"file": "Acme/model.xlsx", "sheet": "P&L", "cell": "B5", "kind": "hardcoded_override", "detail": "Hardcoded 1234"},
+    {"file": "Acme/model.xlsx", "sheet": "P&L", "cell": "C3", "kind": "circular_reference", "detail": "self-ref"},
+    {"file": "Acme/m.xlsx", "sheet": "S", "cell": "A1", "kind": "broken_external_link", "detail": "ext link"},
+]
+
+
+class TestFormulaFindingsBuilder:
+    def test_empty_report_yields_no_findings(self) -> None:
+        out = formula_findings(_report([]), run_id="r", subject="S", subject_safe_name="_m", timestamp="t")
+        assert out == []
+
+    def test_one_finding_per_issue_with_severity_map(self) -> None:
+        out = formula_findings(
+            _report(_ISSUES),
+            run_id="r",
+            subject="Financial models",
+            subject_safe_name="_model_integrity",
+            timestamp="t",
+        )
+        assert len(out) == 3
+        by_kind = {f["metadata"]["kind"]: f for f in out}  # type: ignore[index]
+        assert by_kind["hardcoded_override"]["severity"] == "P2"
+        assert by_kind["circular_reference"]["severity"] == "P2"
+        assert by_kind["broken_external_link"]["severity"] == "P3"
+
+    def test_finding_is_valid_and_cites_exact_cell(self) -> None:
+        out = formula_findings(
+            _report(_ISSUES[:1]),
+            run_id="r",
+            subject="Financial models",
+            subject_safe_name="_model_integrity",
+            timestamp="t",
+        )
+        f = Finding.model_validate(out[0])  # must validate against the Finding contract
+        assert f.agent == "finance"
+        assert f.citations[0].source_path == "Acme/model.xlsx"
+        assert f.citations[0].location == "P&L!B5"
+
+    def test_severity_source_stamped_for_recalibration_guard(self) -> None:
+        out = formula_findings(
+            _report(_ISSUES[:1]),
+            run_id="r",
+            subject="Financial models",
+            subject_safe_name="_model_integrity",
+            timestamp="t",
+        )
+        prov = out[0]["metadata"]["provenance"]  # type: ignore[index]
+        assert prov["severity_source"] == "formula_auditor"
+
+    def test_ids_are_deterministic(self) -> None:
+        a = formula_findings(_report(_ISSUES), run_id="r1", subject="S", subject_safe_name="_m", timestamp="t1")
+        b = formula_findings(_report(_ISSUES), run_id="r2", subject="S", subject_safe_name="_m", timestamp="t2")
+        # ids are content-derived, independent of run_id/timestamp.
+        assert [f["id"] for f in a] == [f["id"] for f in b]
+
+
+class TestInjectFormulaFindings:
+    def _merger(self) -> FindingMerger:
+        return FindingMerger(run_id="r1", config_hash="h", prompt_version="1.0.0")
+
+    def test_creates_synthetic_subject_and_persists_findings(self) -> None:
+        merged: dict[str, MergedSubjectOutput] = {}
+        n = self._merger().inject_formula_findings(merged, _report(_ISSUES))
+        assert n == 3
+        assert "_model_integrity" in merged
+        assert len(merged["_model_integrity"].findings) == 3
+        assert merged["_model_integrity"].findings[0].agent == "finance"
+
+    def test_idempotent_under_resume(self) -> None:
+        merged: dict[str, MergedSubjectOutput] = {}
+        m = self._merger()
+        m.inject_formula_findings(merged, _report(_ISSUES))
+        n2 = m.inject_formula_findings(merged, _report(_ISSUES))  # second pass
+        assert n2 == 0
+        assert len(merged["_model_integrity"].findings) == 3
+
+    def test_empty_report_is_noop(self) -> None:
+        merged: dict[str, MergedSubjectOutput] = {}
+        n = self._merger().inject_formula_findings(merged, _report([]))
+        assert n == 0
+        assert merged == {}
+
+    def test_findings_survive_recalibration_guard(self) -> None:
+        # The recalibration guard must NO-OP on a finding with severity_source set,
+        # preserving the formula auditor's severity.
+        from dd_agents.reporting.computed_metrics import ReportDataComputer
+
+        merged: dict[str, MergedSubjectOutput] = {}
+        self._merger().inject_formula_findings(merged, _report(_ISSUES[:1]))
+        raw = merged["_model_integrity"].findings[0].model_dump()
+        out = ReportDataComputer._recalibrate_severity(raw)
+        assert out["severity"] == "P2"  # unchanged by the read-only guard

--- a/tests/unit/test_html_parity_sections.py
+++ b/tests/unit/test_html_parity_sections.py
@@ -1,0 +1,112 @@
+"""Tests for HTML/PDF parity of Excel-only sections (Issue #244).
+
+Covers the ContractDatesRenderer, the QualityRenderer entity-resolution block,
+and the CompletenessRenderer reference-files block — XSS-safe + parity (nothing
+when data absent).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dd_agents.reporting.computed_metrics import ReportDataComputer
+from dd_agents.reporting.html_completeness import CompletenessRenderer
+from dd_agents.reporting.html_contract_dates import ContractDatesRenderer
+from dd_agents.reporting.html_quality import QualityRenderer
+
+
+def _computed() -> Any:
+    return ReportDataComputer().compute({})
+
+
+class TestContractDatesRenderer:
+    def test_parity_empty_when_absent(self) -> None:
+        assert ContractDatesRenderer(_computed(), {}, {"_run_metadata": {}}).render() == ""
+        assert ContractDatesRenderer(_computed(), {}, {"_run_metadata": None}).render() == ""
+
+    def test_renders_entries_and_arr_kpis(self) -> None:
+        recon = {
+            "entries": [
+                {
+                    "subject": "Acme Corp",
+                    "status": "Expired-Confirmed",
+                    "database_end_date": "2025-12-31",
+                    "actual_end_date": "2024-06-30",
+                    "arr": 500000.0,
+                    "evidence": "Contract expired",
+                    "evidence_file": "Acme/msa.pdf",
+                }
+            ],
+            "total_expired_arr": 500000.0,
+            "total_reclassified_arr": 0.0,
+        }
+        html = ContractDatesRenderer(
+            _computed(), {}, {"_run_metadata": {"contract_date_reconciliation": recon}}
+        ).render()
+        assert "Contract Date Reconciliation" in html
+        assert "Acme Corp" in html
+        assert "Expired-Confirmed" in html
+        assert "id='sec-contract-dates'" in html
+        assert "$500K" in html  # fmt_currency abbreviates
+
+    def test_escapes_subject_and_evidence(self) -> None:
+        recon = {
+            "entries": [
+                {
+                    "subject": "<script>x</script>",
+                    "status": "s",
+                    "arr": 0,
+                    "evidence": "<img src=x>",
+                    "evidence_file": "",
+                }
+            ]
+        }
+        html = ContractDatesRenderer(
+            _computed(), {}, {"_run_metadata": {"contract_date_reconciliation": recon}}
+        ).render()
+        assert "<script>x</script>" not in html
+        assert "<img src=x>" not in html
+        assert "&lt;script&gt;" in html
+
+
+class TestEntityResolutionSection:
+    def test_parity_empty_when_no_matches(self) -> None:
+        assert QualityRenderer(_computed(), {}, {"_run_metadata": {}})._render_entity_resolution() == ""
+
+    def test_renders_match_log(self) -> None:
+        matches = [
+            {"source_name": "ACME", "canonical_name": "Acme Corp", "match_method": "fuzzy", "confidence": 0.92},
+        ]
+        html = QualityRenderer(
+            _computed(), {}, {"_run_metadata": {"entity_matches": matches}}
+        )._render_entity_resolution()
+        assert "Entity Resolution Log" in html
+        assert "Acme Corp" in html
+        assert "92%" in html
+
+    def test_escapes_names(self) -> None:
+        matches = [{"source_name": "<b>x</b>", "canonical_name": "y", "match_method": "m", "confidence": "n/a"}]
+        html = QualityRenderer(
+            _computed(), {}, {"_run_metadata": {"entity_matches": matches}}
+        )._render_entity_resolution()
+        assert "<b>x</b>" not in html
+        assert "&lt;b&gt;" in html
+
+
+class TestReferenceFilesSection:
+    def test_parity_empty_when_absent(self) -> None:
+        # No reference_files (and no other completeness data) → whole section empty.
+        assert CompletenessRenderer(_computed(), {}, {"_run_metadata": {}}).render() == ""
+
+    def test_renders_reference_files(self) -> None:
+        refs = [{"file_path": "DD_Output/deck.pptx", "category": "dd_output", "description": "Readout deck"}]
+        html = CompletenessRenderer(_computed(), {}, {"_run_metadata": {"reference_files": refs}}).render()
+        assert "Reference Files (1)" in html
+        assert "DD_Output/deck.pptx" in html
+        assert "id='sec-completeness'" in html
+
+    def test_escapes_reference_paths(self) -> None:
+        refs = [{"file_path": "<x>", "category": "<y>", "description": "<z>"}]
+        html = CompletenessRenderer(_computed(), {}, {"_run_metadata": {"reference_files": refs}}).render()
+        assert "<x>" not in html and "<y>" not in html
+        assert "&lt;x&gt;" in html

--- a/tests/unit/test_vision_cost.py
+++ b/tests/unit/test_vision_cost.py
@@ -1,0 +1,86 @@
+"""Tests for accounting Claude-vision extraction LLM spend (Issue #247).
+
+Covers the pipeline's usage accumulator and the engine's recording into the
+CostTracker (reaching by_model / by_provider / budget gate).
+"""
+
+from __future__ import annotations
+
+from dd_agents.agents.cost_tracker import CostTracker
+from dd_agents.extraction.pipeline import ExtractionPipeline
+
+
+class _Usage:
+    def __init__(self, input_tokens: int, output_tokens: int) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+class TestVisionUsageAccumulator:
+    def test_starts_at_zero(self) -> None:
+        p = ExtractionPipeline()
+        assert p.vision_usage() == (0, 0, 0)
+
+    def test_accumulates_object_usage(self) -> None:
+        p = ExtractionPipeline()
+        p._record_vision_usage(_Usage(100, 50))
+        p._record_vision_usage(_Usage(40, 10))
+        assert p.vision_usage() == (140, 60, 2)
+
+    def test_accumulates_dict_usage(self) -> None:
+        p = ExtractionPipeline()
+        p._record_vision_usage({"input_tokens": 7, "output_tokens": 3})
+        assert p.vision_usage() == (7, 3, 1)
+
+    def test_none_usage_still_counts_the_call(self) -> None:
+        # An errored vision call may report no usage but still happened.
+        p = ExtractionPipeline()
+        p._record_vision_usage(None)
+        # None → not counted (no tokens, no call recorded — we only count usage we saw).
+        assert p.vision_usage() == (0, 0, 0)
+
+    def test_malformed_usage_is_tolerated(self) -> None:
+        p = ExtractionPipeline()
+        p._record_vision_usage({"input_tokens": "x", "output_tokens": None})
+        assert p.vision_usage() == (0, 0, 1)
+
+
+class _FakePipeline:
+    def __init__(self, usage: tuple[int, int, int]) -> None:
+        self._u = usage
+
+    def vision_usage(self) -> tuple[int, int, int]:
+        return self._u
+
+
+class TestEngineRecordsVisionCost:
+    def _engine(self):  # type: ignore[no-untyped-def]
+        from dd_agents.orchestrator.engine import PipelineEngine
+
+        eng = PipelineEngine.__new__(PipelineEngine)
+        eng.cost_tracker = CostTracker()
+        return eng
+
+    def test_records_vision_spend_into_tracker(self, monkeypatch) -> None:  # noqa: ANN001
+        monkeypatch.setenv("DD_VISION_MODEL", "claude-sonnet-4-6")
+        eng = self._engine()
+        eng._record_vision_cost(_FakePipeline((1000, 200, 3)))
+        by_model = eng.cost_tracker.cost_by_model()
+        assert "claude-sonnet-4-6" in by_model
+        entries = [e for e in eng.cost_tracker.entries if e.agent_name == "extraction_vision"]
+        assert len(entries) == 1
+        assert entries[0].input_tokens == 1000
+        assert entries[0].step == "05_bulk_extraction"
+
+    def test_no_vision_calls_is_noop(self) -> None:
+        eng = self._engine()
+        eng._record_vision_cost(_FakePipeline((0, 0, 0)))
+        assert eng.cost_tracker.entries == []
+
+    def test_vision_spend_counts_toward_budget_gate(self, monkeypatch) -> None:  # noqa: ANN001
+        monkeypatch.setenv("DD_VISION_MODEL", "claude-opus-4-8")
+        eng = self._engine()
+        eng.cost_tracker.budget_limit_usd = 0.001
+        # 1M input tokens of Opus = $15 → well over the $0.001 budget.
+        eng._record_vision_cost(_FakePipeline((1_000_000, 0, 1)))
+        assert eng.cost_tracker.is_budget_exceeded() is True

--- a/tests/unit/test_vision_cost.py
+++ b/tests/unit/test_vision_cost.py
@@ -84,3 +84,31 @@ class TestEngineRecordsVisionCost:
         # 1M input tokens of Opus = $15 → well over the $0.001 budget.
         eng._record_vision_cost(_FakePipeline((1_000_000, 0, 1)))
         assert eng.cost_tracker.is_budget_exceeded() is True
+
+
+class TestVisionByProvider:
+    """#247 vision spend appears in the by-provider rollup (audit-noted gap)."""
+
+    def test_vision_entry_carries_provider_and_rolls_up(self, monkeypatch) -> None:  # noqa: ANN001
+        import dd_agents.llm as llm_mod
+        from dd_agents.llm import ProviderInfo
+
+        monkeypatch.setenv("DD_VISION_MODEL", "claude-sonnet-4-6")
+        # _record_vision_cost does `from dd_agents.llm import resolve_provider`,
+        # so patch the function on the llm module (its import source).
+        monkeypatch.setattr(
+            llm_mod,
+            "resolve_provider",
+            lambda: ProviderInfo(provider="gateway", base_url="http://gw:4011", max_output_tokens=None),
+        )
+        from dd_agents.orchestrator.engine import PipelineEngine
+
+        eng = PipelineEngine.__new__(PipelineEngine)
+        eng.cost_tracker = CostTracker()
+        eng._record_vision_cost(_FakePipeline((1000, 200, 2)))
+        entry = next(e for e in eng.cost_tracker.entries if e.agent_name == "extraction_vision")
+        assert entry.provider == "gateway"
+        assert entry.base_url == "http://gw:4011"
+        by_provider = eng.cost_tracker.cost_by_provider()
+        assert "gateway" in by_provider
+        assert by_provider["gateway"]["input_tokens"] == 1000


### PR DESCRIPTION
Deliverable-completeness & audit-integrity release. Zero new dependencies.

## #245 — formula-integrity issues become first-class findings
`formula_audit.formula_findings()` mints citable Finance findings (kind→severity; `severity_source=formula_auditor` so `resolve_severity`/recalibration treat them as resolved — Rule 12). `merge.inject_formula_findings()` persists them to `findings/merged/_model_integrity.json` at the merge step (content-stable SHA-256 ids, idempotent under `--resume`), so model-integrity issues reach the **findings index (query/chat), counts, audit, severity rollups, and the executive summary** — not just the report.

## #244 — HTML/PDF parity for Excel-only sections
New `ContractDatesRenderer` (active-vs-expired ARR + KPI line), a `QualityRenderer` entity-resolution match-log block, and a `CompletenessRenderer` reference-files disclosure. All read `run_metadata` (the same data Excel uses), XSS-safe, parity-safe, wired into `html.py` + nav. PDF inherits.

## #247 — Claude-vision extraction cost accounting
`ExtractionPipeline` accumulates vision `ResultMessage.usage` (thread-safe); the engine records it into `CostTracker` as `extraction_vision` with the resolved provider/base_url (secret-free) → reaches `by_model`/`by_provider`/`total` + the budget gate. No-op when the fallback never fires.

## Quality
- **19-agent adversarial audit** → 15 raw findings, 10 refuted, **5 confirmed, all fixed**: stable SHA-256 finding ids (was process-salted `hash()`); synthetic `_model_integrity` subject excluded from entity counts/governance/HHI/Entity-Detail via `is_synthetic_subject()` (findings still count); docs refreshed; vision `by_provider` + cross-process id-stability tests added.
- 4478 unit + integration pass; deterministic evals pass; `mypy --strict` + `ruff` clean; `mkdocs build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)