### PR TITLE
chore: update all URLs to zoharbabin.com custom domain

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/dd-agents.svg)](https://pypi.org/project/dd-agents/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](https://github.com/zoharbabin/due-diligence-agents/blob/main/LICENSE)
 
-**[📄 Documentation](https://zoharbabin.github.io/due-diligence-agents/)** · **[📊 Sample Report](https://zoharbabin.github.io/due-diligence-agents/sample-report/)** · **[💻 Source Code](https://github.com/zoharbabin/due-diligence-agents)**
+**[📄 Documentation](https://zoharbabin.com/due-diligence-agents/)** · **[📊 Sample Report](https://zoharbabin.com/due-diligence-agents/sample-report/)** · **[💻 Source Code](https://github.com/zoharbabin/due-diligence-agents)**
 
 ---
 
@@ -111,8 +111,8 @@ services:
 
 ## Links
 
-- **Documentation:** https://zoharbabin.github.io/due-diligence-agents/
-- **Sample Report:** https://zoharbabin.github.io/due-diligence-agents/sample-report/
+- **Documentation:** https://zoharbabin.com/due-diligence-agents/
+- **Sample Report:** https://zoharbabin.com/due-diligence-agents/sample-report/
 - **Source Code:** https://github.com/zoharbabin/due-diligence-agents
 - **PyPI:** https://pypi.org/project/dd-agents/
 - **Issues:** https://github.com/zoharbabin/due-diligence-agents/issues

--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@
 
 ---
 
-**[See a sample report](https://zoharbabin.github.io/due-diligence-agents/sample-report/)** — interactive HTML output from a synthetic deal, no install required.
+**[See a sample report](https://zoharbabin.com/due-diligence-agents/sample-report/)** — interactive HTML output from a synthetic deal, no install required.
 
 ### 📑 Walkthrough deck
 
 <p align="center">
-<a href="https://zoharbabin.github.io/due-diligence-agents/marketing/presentation.html">
+<a href="https://zoharbabin.com/due-diligence-agents/marketing/presentation.html">
 <img src="docs/marketing/assets/presentation-cover.png" alt="Due Diligence Agents — interactive walkthrough presentation (23 slides)" width="720">
 </a>
 </p>
 <p align="center">
-<a href="https://zoharbabin.github.io/due-diligence-agents/marketing/presentation.html"><strong>▶ Open the interactive walkthrough →</strong></a> · 23 slides · architecture, cross-domain synthesis, trust layer, and ROI · use <kbd>←</kbd>/<kbd>→</kbd> to navigate, <kbd>N</kbd> for speaker notes
+<a href="https://zoharbabin.com/due-diligence-agents/marketing/presentation.html"><strong>▶ Open the interactive walkthrough →</strong></a> · 23 slides · architecture, cross-domain synthesis, trust layer, and ROI · use <kbd>←</kbd>/<kbd>→</kbd> to navigate, <kbd>N</kbd> for speaker notes
 </p>
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Documentation
 
 The full documentation site is published at
-**[zoharbabin.github.io/due-diligence-agents](https://zoharbabin.github.io/due-diligence-agents/)**.
+**[zoharbabin.com/due-diligence-agents](https://zoharbabin.com/due-diligence-agents/)**.
 This page indexes the same content for browsing on GitHub.
 
 ## User Guide

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ dd-agents init --data-room ./your_data_room
 dd-agents run deal-config.json
 ```
 
-**[See a sample report →](https://zoharbabin.github.io/due-diligence-agents/sample-report/)**
+**[See a sample report →](https://zoharbabin.com/due-diligence-agents/sample-report/)**
 
 ## What It Does
 

--- a/docs/marketing/devto-trust-layer.md
+++ b/docs/marketing/devto-trust-layer.md
@@ -187,7 +187,7 @@ And the meta-point: **be honest in your own docs about which layer is which.** I
 
 Open-source (Apache 2.0), Python 3.12+. No vendor lock-in: runs on the Anthropic API, your own AWS Bedrock or Google Vertex account, or any model (GPT, Gemini, local) behind an Anthropic-compatible gateway — all by env config.
 
-**See the output without installing → [interactive sample report](https://zoharbabin.github.io/due-diligence-agents/sample-report/)** (from a synthetic deal — no real data).
+**See the output without installing → [interactive sample report](https://zoharbabin.com/due-diligence-agents/sample-report/)** (from a synthetic deal — no real data).
 
 ```bash
 pip install dd-agents
@@ -195,6 +195,6 @@ pip install dd-agents
 
 {% github zoharbabin/due-diligence-agents %}
 
-Go deeper: the [System Card](https://zoharbabin.github.io/due-diligence-agents/system-card/) (full trust posture, stated limits) and ["How the Agents Work"](https://zoharbabin.github.io/due-diligence-agents/agent-anatomy/) (a plain-English tour of the agents and the safety floor).
+Go deeper: the [System Card](https://zoharbabin.com/due-diligence-agents/system-card/) (full trust posture, stated limits) and ["How the Agents Work"](https://zoharbabin.com/due-diligence-agents/agent-anatomy/) (a plain-English tour of the agents and the safety floor).
 
 If you're building LLM systems where being wrong has a real cost, I'd genuinely like to hear how you draw the deterministic-vs-probabilistic line. The mechanisms above are my current best answers — and the honest limit is where I'd most welcome better ideas.

--- a/docs/marketing/distribution-channels.md
+++ b/docs/marketing/distribution-channels.md
@@ -85,7 +85,7 @@ Every new install path = a new discovery surface + credibility:
 ## Positioning notes per track (keep messaging honest + on-brand)
 - **Dev channels** → lead with the tagline's *mechanism*: open-source, 13 agents, cross-reference across 9 domains, cite to an exact quote, runs local. Show `pip install dd-agents` + the sample report.
 - **M&A channels** → lead with the *pain*: the buried clause nobody connects across siloed workstreams; "accelerates your advisors, doesn't replace them" (never "board-ready", never "replaces advisors").
-- **Everywhere**: the [live sample report](https://zoharbabin.github.io/due-diligence-agents/sample-report/) is the zero-friction "aha" — link it in every listing.
+- **Everywhere**: the [live sample report](https://zoharbabin.com/due-diligence-agents/sample-report/) is the zero-friction "aha" — link it in every listing.
 
 ## Anti-patterns (from the research)
 - Don't dump the same blurb everywhere (duplicate-content penalty).

--- a/docs/marketing/launch-copy-pack.md
+++ b/docs/marketing/launch-copy-pack.md
@@ -1,7 +1,7 @@
 # Due Diligence Agents — Launch Copy Pack (final, ship-ready)
 
 **Maker:** Zohar Babin (solo) · **Launch:** Product Hunt, 12:01am PT
-**Links:** github.com/zoharbabin/due-diligence-agents · `pip install dd-agents` · sample report: zoharbabin.github.io/due-diligence-agents/sample-report/
+**Links:** github.com/zoharbabin/due-diligence-agents · `pip install dd-agents` · sample report: zoharbabin.com/due-diligence-agents/sample-report/
 
 **Unified voice (applied throughout):** dry, confident, evidence-first. No swagger, no buzzword soup. The villain is always the *gap between silos*, never a person. The hero is *clarity*. Every claim is literally true to the product. The tool **accelerates** advisors and **cites** its work — humans decide.
 
@@ -47,7 +47,7 @@ So I built Due Diligence Agents. 13 AI agents read your entire data room across 
 
 What makes it different: the cross-domain connection is the whole point, and forensic citation is the proof. It's open-source (Apache-2.0) and runs locally — your documents only leave as API calls to your own LLM provider. **No vendor lock-in:** run it on the Anthropic API, your own AWS Bedrock or Google Vertex account, or *any* model (GPT, Gemini, a local model) behind an Anthropic-compatible gateway — all by env config, no code change. `dd-agents doctor` verifies your setup before a run, and every run records which provider/model produced the findings. It accelerates your advisors; humans still decide.
 
-See a sample report (no install): https://zoharbabin.github.io/due-diligence-agents/sample-report/
+See a sample report (no install): https://zoharbabin.com/due-diligence-agents/sample-report/
 Code: https://github.com/zoharbabin/due-diligence-agents · `pip install dd-agents`
 
 I'm here all day. Drop feature requests in the comments and I'll build live, and I'm happy to give anyone a personal walkthrough.
@@ -193,7 +193,7 @@ We're live on Product Hunt today and I'd genuinely love your feedback — what's
 
 → PH: [Product Hunt link]
 → Code: github.com/zoharbabin/due-diligence-agents
-→ Live sample report: zoharbabin.github.io/due-diligence-agents/sample-report/
+→ Live sample report: zoharbabin.com/due-diligence-agents/sample-report/
 
 Built solo. Tell me where it's wrong. 🙏
 
@@ -215,7 +215,7 @@ Runs locally. Your documents never leave your environment except as API calls to
 
 We're live on Product Hunt today. I'd genuinely value your read on it — see a sample report and tell me where it's wrong:
 
-Sample report: https://zoharbabin.github.io/due-diligence-agents/sample-report/
+Sample report: https://zoharbabin.com/due-diligence-agents/sample-report/
 Code: github.com/zoharbabin/due-diligence-agents
 
 Feedback welcome — especially the critical kind.
@@ -227,13 +227,13 @@ Feedback welcome — especially the critical kind.
 ## 6. Supporter DM Templates (feedback, never upvotes)
 
 **1. Close connection**
-Hey [Name] — launching something today I think you'll have opinions on. It's an open-source tool that cross-references M&A diligence findings across domains (the legal-flag-meets-finance-flag problem we've both lived) and cites every flag to an exact quote. I'm not after upvotes — I genuinely want your gut reaction, especially anything that feels off. Sample report's here if you have 5 min: https://zoharbabin.github.io/due-diligence-agents/sample-report/ — would love your honest take.
+Hey [Name] — launching something today I think you'll have opinions on. It's an open-source tool that cross-references M&A diligence findings across domains (the legal-flag-meets-finance-flag problem we've both lived) and cites every flag to an exact quote. I'm not after upvotes — I genuinely want your gut reaction, especially anything that feels off. Sample report's here if you have 5 min: https://zoharbabin.com/due-diligence-agents/sample-report/ — would love your honest take.
 
 **2. Professional network**
-Hi [Name] — I've been building a forensic M&A diligence tool and it's live on Product Hunt today. The idea came from a pain I suspect you know: siloed advisor reports where the real risk lives between the domains nobody connects. It reads the full data room across nine domains, cross-references, and traces every finding to a verbatim source. It accelerates a deal team, doesn't replace it. No ask for votes — I'd just value your professional read and any pushback. Sample: https://zoharbabin.github.io/due-diligence-agents/sample-report/
+Hi [Name] — I've been building a forensic M&A diligence tool and it's live on Product Hunt today. The idea came from a pain I suspect you know: siloed advisor reports where the real risk lives between the domains nobody connects. It reads the full data room across nine domains, cross-references, and traces every finding to a verbatim source. It accelerates a deal team, doesn't replace it. No ask for votes — I'd just value your professional read and any pushback. Sample: https://zoharbabin.com/due-diligence-agents/sample-report/
 
 **3. Fellow founder**
-Hey [Name] — shipped my thing today, open-source, on Product Hunt. It's AI agents for M&A due diligence: read every doc, connect every domain, cite every flag — and it halts rather than ship anything it can't verify. You know the launch-day drill, so no upvote ask — what I'd actually value is a builder's eye on it. Where's the positioning weak? What would make you bounce? Repo and a live sample report: github.com/zoharbabin/due-diligence-agents · https://zoharbabin.github.io/due-diligence-agents/sample-report/ — brutal feedback more than welcome.
+Hey [Name] — shipped my thing today, open-source, on Product Hunt. It's AI agents for M&A due diligence: read every doc, connect every domain, cite every flag — and it halts rather than ship anything it can't verify. You know the launch-day drill, so no upvote ask — what I'd actually value is a builder's eye on it. Where's the positioning weak? What would make you bounce? Repo and a live sample report: github.com/zoharbabin/due-diligence-agents · https://zoharbabin.com/due-diligence-agents/sample-report/ — brutal feedback more than welcome.
 
 ---
 

--- a/docs/marketing/presentation.html
+++ b/docs/marketing/presentation.html
@@ -790,7 +790,7 @@ Executive synthesis:   <span class="r">Opus</span>    <span class="cm">($15 / M 
     <div class="big-quote">The gap between an AI demo and a system a deal team can <span class="grad-g">put its name on</span> is entirely engineering.</div>
     <p class="sub" style="margin-top:24px">74% → 95% accuracy came from extraction, chunking, citation verification, deterministic gates, and cross-domain synthesis — not from a bigger model. That discipline is what makes this usable for real M&amp;A.</p>
     <div class="grid g3" style="margin-top:10px;max-width:880px">
-      <div class="card"><div class="lead">Try it live</div><p class="small">Interactive sample report — no install:<br><span class="mono" style="color:var(--cyan)">zoharbabin.github.io/<br>due-diligence-agents/sample-report/</span></p></div>
+      <div class="card"><div class="lead">Try it live</div><p class="small">Interactive sample report — no install:<br><span class="mono" style="color:var(--cyan)">zoharbabin.com/due-diligence-agents/sample-report/</span></p></div>
       <div class="card"><div class="lead">The code</div><p class="small"><span class="mono">pip install dd-agents</span><br>Apache-2.0 · 4,000+ tests · open source</p></div>
       <div class="card tint-p"><div class="lead">Next step</div><p class="small">A working session on a real (or synthetic) data room — a live run, end-to-end.</p></div>
     </div>

--- a/docs/marketing/producthunt-launch-plan.md
+++ b/docs/marketing/producthunt-launch-plan.md
@@ -232,7 +232,7 @@ The launch is the **starting line**, not the finish (every guide hammers this):
 ### Source notes
 Synthesized 2026-06-05 from: GojiberryAI #1 guide (Czerny/LinkedIn), Momen #1 case study (Alex Chen), Unusual Ventures × Social Growth Labs (100+ top-3 launches; the "1 comment ≈ 40–50 upvotes" + karma/credibility data), Meetric Top-5 "what NOT to do" (Boudet), the 4-week SaaS-directory guide (AutoSaaSLaunch), the macOS-app PH guide, Preevy OSS playbook (Livecycle, 1.5k★), OpenSaaS OSS guide (Wasp, 6k★). All are point-in-time external advice — re-verify PH's current submission specs/limits on the PH site before locking assets.
 
-[sample report]: https://zoharbabin.github.io/due-diligence-agents/sample-report/
-[presentation]: https://zoharbabin.github.io/due-diligence-agents/marketing/presentation.html
+[sample report]: https://zoharbabin.com/due-diligence-agents/sample-report/
+[presentation]: https://zoharbabin.com/due-diligence-agents/marketing/presentation.html
 [demo video]: ./LAUNCH-ASSETS.md
 [trust-layer article]: ./devto-trust-layer.md

--- a/docs/marketing/video-brief.md
+++ b/docs/marketing/video-brief.md
@@ -34,7 +34,7 @@ Edit a single master timeline, then export three cuts:
 **Production specs:**
 - Subtitles burned in (open captions) — most watch muted; the dialogue/VO must read silently.
 - Terminal + screen recordings at 2× readability: large font (≥18pt), high-contrast theme, cursor-zoom on key moments (Screen Studio / Screen Charm style). Never show a raw 12-pt terminal.
-- Real product, real (synthetic) data — actual `dd-agents` CLI output and the live HTML sample report (`zoharbabin.github.io/due-diligence-agents/sample-report/`). No faked UI.
+- Real product, real (synthetic) data — actual `dd-agents` CLI output and the live HTML sample report (`zoharbabin.com/due-diligence-agents/sample-report/`). No faked UI.
 - Brand: iris logo + palette (`docs/marketing/assets/logo.svg`); reuse `social-preview.png` end card.
 - Music: tense, minimal, building pulse (think understated electronic) → resolves to a clean, confident button at the CTA. Duck under all VO.
 - Pace: cold open fast; demo section breathes (let one real finding land); CTA crisp.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -122,7 +122,7 @@ data_room/
 
 **Folder structure matters:** The tool uses folder names to identify which documents belong to which subject. A flat folder of files with no subfolder structure will still work — the tool groups them as a single entity — but organizing by subject produces better results.
 
-A pre-built sample deal — **Project Atlas** — is included at [`examples/project-atlas/`](https://github.com/zoharbabin/due-diligence-agents/tree/main/examples/project-atlas) so you can try the tool before setting up your own files. It is the same synthetic deal behind the [live sample report](https://zoharbabin.github.io/due-diligence-agents/sample-report/). Run it with `dd-agents run examples/project-atlas/deal-config.json`.
+A pre-built sample deal — **Project Atlas** — is included at [`examples/project-atlas/`](https://github.com/zoharbabin/due-diligence-agents/tree/main/examples/project-atlas) so you can try the tool before setting up your own files. It is the same synthetic deal behind the [live sample report](https://zoharbabin.com/due-diligence-agents/sample-report/). Run it with `dd-agents run examples/project-atlas/deal-config.json`.
 
 ## Pre-Flight Check
 

--- a/examples/project-atlas/README.md
+++ b/examples/project-atlas/README.md
@@ -51,7 +51,7 @@ Output lands at `examples/project-atlas/sample_data_room/_dd/forensic-dd/runs/la
 (`dd_report.html` + `dd_report.xlsx`). The `_dd/` working directory is gitignored.
 
 > Want to see the result without running anything? Open the
-> [live sample report](https://zoharbabin.github.io/due-diligence-agents/sample-report/) —
+> [live sample report](https://zoharbabin.com/due-diligence-agents/sample-report/) —
 > it is this exact deal's real output.
 
 ## The data room

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: DD-Agents Documentation
-site_url: https://zoharbabin.github.io/due-diligence-agents/
+site_url: https://zoharbabin.com/due-diligence-agents/
 site_description: Legal flags a risk. Finance flags another. We connect and cite. Open-source forensic M&A due diligence — 13 AI agents read your entire data room across 9 domains, cross-reference findings no single reviewer connects, and trace every one to an exact quote.
 site_author: Zohar Babin
 repo_url: https://github.com/zoharbabin/due-diligence-agents
@@ -71,7 +71,7 @@ nav:
     - System Card: system-card.md
     - Eval Datasheet: eval-datasheet.md
   - Contributing: contributing.md
-  - Sample Report: https://zoharbabin.github.io/due-diligence-agents/sample-report/
+  - Sample Report: https://zoharbabin.com/due-diligence-agents/sample-report/
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ docs = ["mkdocs-material>=9.5"]
 [project.urls]
 Homepage = "https://github.com/zoharbabin/due-diligence-agents"
 Repository = "https://github.com/zoharbabin/due-diligence-agents"
-Documentation = "https://zoharbabin.github.io/due-diligence-agents/"
+Documentation = "https://zoharbabin.com/due-diligence-agents/"
 Issues = "https://github.com/zoharbabin/due-diligence-agents/issues"
 Changelog = "https://github.com/zoharbabin/due-diligence-agents/releases"
 


### PR DESCRIPTION
## Summary
Replace all `zoharbabin.github.io/due-diligence-agents` references with `zoharbabin.com/due-diligence-agents` across docs, config, and marketing copy.

## Why
`zoharbabin.com` is now live as a custom domain on GitHub Pages. GitHub automatically serves the project at `zoharbabin.com/due-diligence-agents/` — this update makes `site_url`, canonical links, sitemaps, OG tags, and all doc links reflect the authoritative domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)