### PR TITLE
v1.18.0 — diff command, --json parity for health/memo/search, vector-search hint, docs (#254-258)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ node_modules/
 # Development artifacts
 cache/
 report-*.png
+
+# Discoverability & DX harness run logs (scripts/discoverability-dx-harness.sh)
+.dx-harness-out/

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ dd-agents portfolio compare                                 # Compare risk acros
 dd-agents export-pdf report.html                            # Export to PDF
 dd-agents log --data-room ./data_room                       # Browse the deal knowledge timeline
 dd-agents lineage --data-room ./data_room                   # Trace finding evolution across runs
+dd-agents diff run_a/ run_b/                                # Compare findings between two run directories
 dd-agents health --data-room ./data_room                    # Check knowledge base integrity
 dd-agents annotate --data-room ./data_room "Confirmed with counsel"  # Add analyst notes
 ```

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ dd-agents run deal-config.json
 
 Analyzes every document through 9 domain lenses, cross-references findings, and validates quality through 5 blocking gates. Produces:
 
-- **Interactive HTML report** — Go/No-Go verdict with executive narrative, progressive disclosure (decision → actions → domain details → full evidence), severity filtering
+- **Interactive HTML report** — Go/No-Go verdict with executive narrative, progressive disclosure (decision → actions → domain details → full evidence), severity filtering, and a clause library section that groups findings by canonical clause type (change of control, termination, indemnification, and more) against market-norm comparisons
 - **16-sheet Excel report** — structured findings, cross-references, audit trail for downstream modeling
 - **Per-subject JSON findings** — every finding with severity, citations, cross-references, and governance graph edges
 

--- a/docs/agent-anatomy.md
+++ b/docs/agent-anatomy.md
@@ -145,6 +145,19 @@ or duplicate the marker, the tool refuses to run rather than guess (a
 
 ---
 
+## The clause library
+
+Every finding a specialist writes up is also checked against a built-in
+**clause taxonomy** (`reporting/clause_library.py`) — canonical clause types
+like change of control, termination for convenience, indemnification, and
+liability caps, each with its typical market norm and risk implications.
+Matched findings are grouped by clause type into a **Clause Analysis** section
+in the HTML report, so a reviewer can see, for example, every finding that
+touches change-of-control clauses across all subjects in one place, alongside
+what "standard" looks like for that clause type.
+
+---
+
 ## The contract-search templates
 
 Separate from the full diligence pipeline, the tool offers a focused

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ dd-agents run deal-config.json
 | `dd-agents chat` | Interactive multi-turn chat about findings |
 | `dd-agents query` | Single-question mode |
 | `dd-agents assess` | Data room quality check |
+| `dd-agents diff` | Compare findings between two run directories |
 
 ## What dd-agents does (and does not) do
 

--- a/docs/knowledge-architecture.md
+++ b/docs/knowledge-architecture.md
@@ -419,6 +419,12 @@ Every architecture embodies tradeoffs. These are the ones we made explicitly, wi
 **Why**: Keyword search and agent tool access are sufficient for 400 documents. Vector search adds value for semantic queries ("find clauses similar to this indemnification") but is not necessary for the core analysis pipeline.
 **Reconsidering at**: 500+ documents, or when cross-document semantic patterns become a primary analysis mode.
 
+### Experimental graph reasoning vs. wiring `ContractKnowledgeGraph` into a query surface
+
+**Chose**: Document as experimental. `ContractKnowledgeGraph` (`reasoning/contract_graph.py`) is a standalone, non-wired reasoning primitive — no pipeline step, CLI command, or report section constructs one today.
+**Why**: this milestone's scope is discoverability/DX, not new reasoning capability. Wiring the graph into a query surface is a materially larger, LLM-touching change that's harder to test deterministically than a docs/DX pass.
+**Reconsidering at**: a concrete query surface (chat tool, CLI command) needs cross-contract relationship queries the existing per-subject findings and search tools can't answer.
+
 ---
 
 ## 11. Research Foundations

--- a/docs/user-guide/cli-reference.md
+++ b/docs/user-guide/cli-reference.md
@@ -269,6 +269,7 @@ dd-agents search PROMPTS_PATH [OPTIONS]
 | `--yes / -y` | flag | off | Skip cost confirmation prompt |
 | `--no-file` | flag | off | Skip filing search results back to Knowledge Base |
 | `--verbose / -v` | flag | off | Enable debug logging |
+| `--json` | flag | off | Print structured per-subject results as JSON instead of writing an Excel report (scriptable; skips the Excel write and console chrome) |
 
 **Examples:**
 
@@ -283,6 +284,9 @@ dd-agents search prompts.json --data-room ./data_room \
 # Save to specific file with higher concurrency
 dd-agents search prompts.json --data-room ./data_room \
   --output results.xlsx --concurrency 10
+
+# Machine-readable output for scripting/CI
+dd-agents search prompts.json --data-room ./data_room --json -y
 ```
 
 ---
@@ -367,6 +371,7 @@ dd-agents memo --report <run_dir> [OPTIONS]
 | `--report` | Path | (required) | Pipeline run directory (contains `findings/merged/`) |
 | `--output` | Path | `<run>/report/ic_memo.md` | Output memo path (Markdown); an `.html` sibling is also written |
 | `--deal-config` | Path | auto-discovered | `deal-config.json` for the memo header; found by walking up from the run dir if omitted |
+| `--json` | flag | off | Print the memo's Go/No-Go + risks + recommendations as JSON instead of writing Markdown/HTML files |
 
 Deterministically assembles a memo (Markdown + HTML) from the run's merged
 findings — Go/No-Go signal, key takeaways, top risks with cited evidence,
@@ -378,6 +383,9 @@ PDF with `dd-agents export-pdf` on the emitted `.html`.
 ```bash
 dd-agents memo --report _dd/forensic-dd/runs/latest
 dd-agents export-pdf _dd/forensic-dd/runs/latest/report/ic_memo.html
+
+# Machine-readable output for scripting/CI (skips the Markdown/HTML write)
+dd-agents memo --report _dd/forensic-dd/runs/latest --json
 ```
 
 ---
@@ -678,6 +686,39 @@ dd-agents lineage --data-room ./data_room --format csv --output lineage.csv
 
 ---
 
+## diff
+
+Compare findings between two arbitrary run directories.
+
+```
+dd-agents diff RUN_A RUN_B [OPTIONS]
+```
+
+**Arguments:**
+- `RUN_A` -- The current (newer) run directory
+- `RUN_B` -- The prior (older) run directory
+
+`RUN_A` is treated as the current run and `RUN_B` as the prior run — matching
+the direction reported by resolved/new findings. Reads only the
+`findings/merged/` directories under each path; no recompute, no LLM call.
+
+**Options:**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--json` | flag | off | Output the diff as JSON |
+| `--output` | path | none | Write a standalone diff HTML report to this path |
+
+**Examples:**
+
+```bash
+dd-agents diff runs/run_b runs/run_a
+dd-agents diff runs/run_b runs/run_a --json
+dd-agents diff runs/run_b runs/run_a --output diff_report.html
+```
+
+---
+
 ## health
 
 Run automated integrity checks against the Deal Knowledge Base.
@@ -692,12 +733,14 @@ dd-agents health [OPTIONS]
 |--------|------|---------|-------------|
 | `--data-room` | path | required | Path to the data room folder |
 | `--auto-fix` | flag | off | Automatically fix broken links and orphan articles |
+| `--json` | flag | off | Output the health-check result as JSON |
 
 **Examples:**
 
 ```bash
 dd-agents health --data-room ./data_room
 dd-agents health --data-room ./data_room --auto-fix
+dd-agents health --data-room ./data_room --json
 ```
 
 Checks 7 categories: staleness, orphans, broken links, missing coverage, citation drift, graph integrity, and lineage gaps.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -46,6 +46,8 @@ pip install dd-agents[ocr]        # OCR for scanned PDFs (English)
 pip install dd-agents[glm-ocr]    # Multilingual OCR (100+ languages, Apple Silicon)
 ```
 
+See [When to Enable Vector Search](#when-to-enable-vector-search) below for guidance on `dd-agents[vector]`.
+
 ### Optional System Dependencies
 
 | Dependency | macOS | Linux | Purpose |
@@ -123,6 +125,24 @@ data_room/
 **Folder structure matters:** The tool uses folder names to identify which documents belong to which subject. A flat folder of files with no subfolder structure will still work — the tool groups them as a single entity — but organizing by subject produces better results.
 
 A pre-built sample deal — **Project Atlas** — is included at [`examples/project-atlas/`](https://github.com/zoharbabin/due-diligence-agents/tree/main/examples/project-atlas) so you can try the tool before setting up your own files. It is the same synthetic deal behind the [live sample report](https://zoharbabin.com/due-diligence-agents/sample-report/). Run it with `dd-agents run examples/project-atlas/deal-config.json`.
+
+### Audio/Video Transcription
+
+Audio and video files in the data room (`.mp3`, `.wav`, `.m4a`, `.mp4`, `.mov`, and similar) are automatically transcribed to text before analysis — no extra step needed. Board call recordings, earnings calls, or deposition audio drop into a subject folder like any other document.
+
+Transcription tries three backends in order, using whichever is installed:
+
+1. **mlx_whisper** — Apple Silicon, fastest on macOS
+2. **whisperx** — GPU-accelerated, cross-platform
+3. **openai-whisper** — broadest compatibility, no GPU required
+
+Install at least one (e.g. `pip install openai-whisper`) for transcription to run; without any backend, media files are skipped. Force a specific backend with `DD_TRANSCRIPTION_BACKEND` (`mlx`, `whisperx`, or `openai`), and override the model with `DD_TRANSCRIPTION_MODEL`.
+
+### When to Enable Vector Search
+
+Keyword search and agent tool access are sufficient for most data rooms. Vector search (`pip install dd-agents[vector]`, backed by ChromaDB) adds value for semantic, cross-document queries, but isn't necessary for the core analysis pipeline below **500 documents** — see [Knowledge Architecture](../knowledge-architecture.md#optional-vector-search-vs-mandatory-vector-search) for the full reasoning. Past that threshold, or once cross-document semantic patterns become a primary analysis mode, install the extra.
+
+If your data room crosses ~500 files and `dd-agents[vector]` isn't installed, `dd-agents run` logs an advisory warning (with `--verbose`) — it never blocks the pipeline.
 
 ## Pre-Flight Check
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -249,6 +249,14 @@ Export the HTML report to a print-ready PDF:
 dd-agents export-pdf _dd/forensic-dd/runs/latest/report/dd_report.html
 ```
 
+### Compare Runs
+
+Diff findings between two arbitrary run directories — e.g. after new documents land, or to compare two analysts' runs:
+
+```bash
+dd-agents diff _dd/forensic-dd/runs/run_a _dd/forensic-dd/runs/run_b
+```
+
 ### Portfolio Management
 
 Track multiple due diligence projects and compare risk profiles across deals:

--- a/docs/user-guide/reading-report.md
+++ b/docs/user-guide/reading-report.md
@@ -121,7 +121,7 @@ The Excel report at `dd_report.xlsx` contains 16 sheets:
 | Reference_Files_Index | Index of reference/cross-cutting documents |
 | Entity_Resolution_Log | Entity matching decisions and confidence scores |
 | Quality_Audit | QA validation results and audit trail |
-| Run_Diff | Changes from prior run (incremental mode only) |
+| Run_Diff | Changes from prior run (incremental mode only) — to diff two arbitrary run directories outside incremental mode, use `dd-agents diff run_a run_b` (see [CLI Reference](cli-reference.md#diff)) |
 | Request_List_Completeness | Requested-document reconciliation: received vs. missing-required vs. missing-optional (when a `request_list` is configured) |
 | Model_Integrity | Spreadsheet formula-integrity issues citing exact cells (hardcoded overrides, circular refs, `#REF!`, broken external links) |
 | _Metadata | Run configuration, timing, costs, versions |

--- a/docs/user-guide/running-pipeline.md
+++ b/docs/user-guide/running-pipeline.md
@@ -47,7 +47,7 @@ dd-agents run deal-config.json --mode incremental
 | `--model-override AGENT=MODEL` | Per-agent model, e.g. `--model-override legal=claude-opus-4-8` |
 | `--no-knowledge` | Skip knowledge compilation after pipeline run |
 | `--no-narrative` | Skip LLM narrative generation (deterministic report only) |
-| `--verbose / -v` | Enable debug logging |
+| `--verbose / -v` | Enable debug logging (also surfaces the advisory vector-search hint past 500 documents — see [Getting Started](getting-started.md#when-to-enable-vector-search)) |
 
 ### Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dd-agents"
-version = "1.17.0"
+version = "1.18.0"
 description = "Open-source forensic M&A due diligence — 13 AI agents read your data room across 9 domains, cross-reference findings no single reviewer connects, and cite every one to an exact quote"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/discoverability-dx-harness.sh
+++ b/scripts/discoverability-dx-harness.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Harness for the "Roadmap: Discoverability & DX" milestone (issue #269 spec).
+# Runs 6 independent gates, in order, and fails loud on the first non-zero exit.
+# Permanent regression gate for this area — re-run on every future change here.
+set -eo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+OUT_DIR=".dx-harness-out"
+mkdir -p "$OUT_DIR"
+
+echo "=== Gate 1: Lint ==="
+python -m ruff check src/ tests/ | tee "$OUT_DIR/01-lint.log"
+
+echo "=== Gate 2: SAST (bandit) ==="
+python -m bandit -r src/dd_agents -ll -q | tee "$OUT_DIR/02-bandit.log"
+
+echo "=== Gate 3: Multi-instance isolation ==="
+python -m pytest tests/unit/test_dx_harness_isolation.py -x -q | tee "$OUT_DIR/03-isolation.log"
+
+echo "=== Gate 4: Dead-code scan (vulture, diffed against known baseline) ==="
+python -m vulture src/dd_agents --min-confidence 80 > "$OUT_DIR/04-vulture.log" || true
+# Strip line numbers before comparing -- pre-existing findings shift lines as
+# unrelated code changes; only a change in file/message signals real new dead code.
+sed -E 's/^([^:]+):[0-9]+:/\1:/' "$OUT_DIR/04-vulture.log" > "$OUT_DIR/04-vulture-normalized.log"
+if ! diff -u scripts/dx-harness-vulture-baseline.txt "$OUT_DIR/04-vulture-normalized.log"; then
+    echo "New dead code found beyond the pre-existing baseline -- see diff above." >&2
+    exit 1
+fi
+cat "$OUT_DIR/04-vulture.log"
+
+echo "=== Gate 5: Unit/integration tests + strict types ==="
+python -m pytest tests/unit/ -x -q | tee "$OUT_DIR/05-unit.log"
+python -m mypy src/ --strict | tee -a "$OUT_DIR/05-unit.log"
+
+echo "=== Gate 6: E2E flow (diff + --json parity, no API key needed) ==="
+python -m pytest tests/e2e/test_discoverability_dx_flow.py -x -q -m "not e2e and not eval" | tee "$OUT_DIR/06-e2e.log"
+
+echo "=== All discoverability-dx gates passed ==="

--- a/scripts/dx-harness-vulture-baseline.txt
+++ b/scripts/dx-harness-vulture-baseline.txt
@@ -1,0 +1,5 @@
+src/dd_agents/cli.py: unused variable 'no_file' (100% confidence)
+src/dd_agents/knowledge/health.py: unused variable 'max_age_runs' (100% confidence)
+src/dd_agents/orchestrator/team.py: unused variable 'run_suffix' (100% confidence)
+src/dd_agents/reporting/excel.py: unused variable 'column_key' (100% confidence)
+src/dd_agents/vector_store/store.py: unused import 'Settings' (90% confidence)

--- a/src/dd_agents/cli.py
+++ b/src/dd_agents/cli.py
@@ -1271,6 +1271,13 @@ def auto_config(
     default=False,
     help="Enable verbose logging output.",
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Print structured per-subject results as JSON instead of writing an Excel report.",
+)
 def search(
     prompts_path: Path,
     data_room: Path,
@@ -1281,6 +1288,7 @@ def search(
     yes: bool,
     no_file: bool,
     verbose: bool,
+    as_json: bool,
 ) -> None:
     """Search subject contracts using custom prompts.
 
@@ -1292,6 +1300,7 @@ def search(
         dd-agents search prompts.json --data-room ./data_room
         dd-agents search prompts.json --data-room ./data_room --groups Commercial
         dd-agents search prompts.json --data-room ./data_room --subjects "Acme,Beta" -y
+        dd-agents search prompts.json --data-room ./data_room --json -y
     """
     if verbose:
         logging.basicConfig(level=logging.WARNING, format="%(name)s: %(message)s")
@@ -1310,8 +1319,12 @@ def search(
         concurrency=concurrency,
         auto_confirm=yes,
         verbose=verbose,
+        as_json=as_json,
     )
-    runner.run()
+    results = runner.run()
+
+    if as_json:
+        click.echo(json.dumps([r.model_dump() for r in results]))
 
 
 # ---------------------------------------------------------------------------
@@ -1435,6 +1448,99 @@ def _print_cost_summary(data: dict[str, Any]) -> None:
             + (f" models=[{models}]" if models else "")
         )
     console.print()
+
+
+# ---------------------------------------------------------------------------
+# diff command (Issue #257 — standalone run comparison)
+# ---------------------------------------------------------------------------
+
+
+@main.command()
+@click.argument(
+    "run_a",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.argument(
+    "run_b",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output the diff as JSON.")
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write a standalone diff HTML report to this path.",
+)
+def diff(run_a: Path, run_b: Path, as_json: bool, output_path: Path | None) -> None:
+    """Compare findings between two arbitrary run directories.
+
+    RUN_A is treated as the current (newer) run, RUN_B as the prior (older)
+    run — matching the direction reported by resolved/new findings. Reads
+    only the ``findings/merged/`` directories under each path; no recompute,
+    no LLM call.
+
+    \b
+    Example:
+        dd-agents diff runs/run_b runs/run_a
+        dd-agents diff runs/run_b runs/run_a --json
+        dd-agents diff runs/run_b runs/run_a --output diff_report.html
+    """
+    from dd_agents.reporting.diff import ReportDiffBuilder
+
+    builder = ReportDiffBuilder()
+    result = builder.build_diff(
+        current_findings_dir=run_a / "findings",
+        prior_findings_dir=run_b / "findings",
+        current_run_id=run_a.name,
+        prior_run_id=run_b.name,
+    )
+
+    if as_json:
+        click.echo(result.model_dump_json())
+    else:
+        _print_diff_summary(result)
+
+    if output_path is not None:
+        import html as _html
+
+        from dd_agents.reporting.html_diff import DiffRenderer
+
+        html_body = DiffRenderer(None, {}, run_dir=None, diff_data=result.model_dump()).render()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            "<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'>"
+            f"<title>Diff: {_html.escape(run_a.name)} vs {_html.escape(run_b.name)}</title>"
+            "</head><body>" + html_body + "</body></html>",
+            encoding="utf-8",
+        )
+        console.print(f"[dim]Diff report written to {output_path}[/dim]")
+
+
+def _print_diff_summary(result: Any) -> None:
+    """Render a ReportDiff as a rich summary table."""
+    s = result.summary
+    console.print(
+        Panel(
+            f"[bold]{result.prior_run_id}[/bold] -> [bold]{result.current_run_id}[/bold]\n\n"
+            f"[red]New findings:[/red] {s.new_findings}   "
+            f"[green]Resolved:[/green] {s.resolved_findings}   "
+            f"[yellow]Changed severity:[/yellow] {s.changed_severity}\n"
+            f"[red]New gaps:[/red] {s.new_gaps}   [green]Resolved gaps:[/green] {s.resolved_gaps}\n"
+            f"[cyan]New subjects:[/cyan] {s.new_subjects}   [cyan]Removed subjects:[/cyan] {s.removed_subjects}",
+            title="Run Diff",
+            border_style="cyan",
+        )
+    )
+    if result.changes:
+        table = Table(show_header=True)
+        table.add_column("Type", width=18)
+        table.add_column("Subject", width=24)
+        table.add_column("Detail")
+        for c in result.changes:
+            detail = c.finding_summary or c.details
+            table.add_row(c.change_type, c.subject, detail[:100])
+        console.print(table)
 
 
 # ---------------------------------------------------------------------------
@@ -1761,7 +1867,14 @@ def export_pdf(html_path: Path, output_path: Path | None, engine: str) -> None:
     default=None,
     help="Path to deal-config.json (for the memo header). Auto-discovered from the run dir if omitted.",
 )
-def memo(report_dir: Path, output_path: Path | None, deal_config_path: Path | None) -> None:
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Print the memo's Go/No-Go + risks + recommendations as JSON instead of writing Markdown/HTML files.",
+)
+def memo(report_dir: Path, output_path: Path | None, deal_config_path: Path | None, as_json: bool) -> None:
     """Generate an Investment Committee memo from a completed run.
 
     Deterministically assembles a distributable memo (Markdown + HTML) from the
@@ -1772,6 +1885,7 @@ def memo(report_dir: Path, output_path: Path | None, deal_config_path: Path | No
     \b
     Example:
         dd-agents memo --report _dd/forensic-dd/runs/latest
+        dd-agents memo --report _dd/forensic-dd/runs/latest --json
     """
     import json as _json
 
@@ -1781,10 +1895,11 @@ def memo(report_dir: Path, output_path: Path | None, deal_config_path: Path | No
     run_dir = report_dir.resolve()
     merged_dir = run_dir / "findings" / "merged"
     if not merged_dir.is_dir() or not any(merged_dir.glob("*.json")):
-        _print_error(
-            "No Merged Findings",
-            f"No merged findings found at {merged_dir}.\n  Run the full pipeline first: dd-agents run deal-config.json",
-        )
+        msg = f"No merged findings found at {merged_dir}. Run the full pipeline first: dd-agents run deal-config.json"
+        if as_json:
+            click.echo(_json.dumps({"error": msg}))
+            raise SystemExit(1)
+        _print_error("No Merged Findings", msg)
         raise SystemExit(1)
 
     # Load merged findings into {safe_name: subject_dict} — same shape the
@@ -1801,6 +1916,23 @@ def memo(report_dir: Path, output_path: Path | None, deal_config_path: Path | No
     deal_config = _read_optional_json(deal_config_path) if deal_config_path else _discover_deal_config(run_dir)
 
     computed = ReportDataComputer().compute(merged_data, executive_synthesis=exec_synth)
+
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "go_no_go": computed.verdict,
+                    "deal_risk_score": computed.deal_risk_score,
+                    "deal_risk_label": computed.deal_risk_label,
+                    "top_risks": computed.wolf_pack,
+                    "recommendations": computed.recommendations,
+                    "subjects_analyzed": computed.subjects_analyzed,
+                    "total_findings": computed.total_findings,
+                    "total_gaps": computed.total_gaps,
+                }
+            )
+        )
+        return
 
     memo_md = render_ic_memo(computed, deal_config if isinstance(deal_config, dict) else None)
     md_path = output_path.resolve() if output_path else run_dir / "report" / "ic_memo.md"
@@ -3052,13 +3184,15 @@ def lineage(
     help="Path to the data room folder.",
 )
 @click.option("--auto-fix", is_flag=True, default=False, help="Auto-fix broken links and orphan articles.")
-def health(data_room: Path, auto_fix: bool) -> None:
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output the health-check result as JSON.")
+def health(data_room: Path, auto_fix: bool, as_json: bool) -> None:
     """Run knowledge base health checks.
 
     \b
     Example:
         dd-agents health --data-room ./data_room
         dd-agents health --data-room ./data_room --auto-fix
+        dd-agents health --data-room ./data_room --json
     """
     from dd_agents.knowledge.base import DealKnowledgeBase
     from dd_agents.knowledge.health import KnowledgeHealthChecker
@@ -3067,11 +3201,18 @@ def health(data_room: Path, auto_fix: bool) -> None:
     kb = DealKnowledgeBase(project_dir)
 
     if not kb.exists:
-        console.print("[dim]No knowledge base found. Run the pipeline first.[/dim]")
+        if as_json:
+            click.echo(json.dumps({"error": "No knowledge base found. Run the pipeline first."}))
+        else:
+            console.print("[dim]No knowledge base found. Run the pipeline first.[/dim]")
         return
 
     checker = KnowledgeHealthChecker(kb, data_room_path=project_dir)
     result = checker.run_all_checks(auto_fix=auto_fix)
+
+    if as_json:
+        click.echo(result.model_dump_json())
+        return
 
     # Summary
     status_color = "green" if result.total_issues == 0 else "yellow" if result.total_issues < 5 else "red"

--- a/src/dd_agents/orchestrator/engine.py
+++ b/src/dd_agents/orchestrator/engine.py
@@ -41,6 +41,7 @@ from dd_agents.utils.constants import (
     SEVERITY_P2,
     SEVERITY_P3,
     SUBJECTS_CSV,
+    VECTOR_SEARCH_DOC_THRESHOLD,
     _sev_count_init,
 )
 
@@ -924,7 +925,28 @@ class PipelineEngine:
         state._discovered_files = files  # type: ignore[attr-defined]
 
         logger.info("Discovered %d files", state.total_files)
+        self._maybe_warn_vector_search(state.total_files)
         return state
+
+    @staticmethod
+    def _maybe_warn_vector_search(total_files: int) -> None:
+        """Advisory-only hint to install optional vector search past the doc threshold (#255).
+
+        Reuses the file count already computed by ``_step_04_file_discovery`` --
+        no second filesystem walk. Never blocks the pipeline (Design Rule 8).
+        """
+        if total_files <= VECTOR_SEARCH_DOC_THRESHOLD:
+            return
+        from dd_agents.vector_store.store import CHROMADB_AVAILABLE
+
+        if not CHROMADB_AVAILABLE:
+            logger.warning(
+                "Data room has %d files, above the %d-document vector-search threshold. "
+                "Consider `pip install dd-agents[vector]` for semantic search across documents. "
+                "See docs/user-guide/getting-started.md#when-to-enable-vector-search.",
+                total_files,
+                VECTOR_SEARCH_DOC_THRESHOLD,
+            )
 
     async def _step_05_bulk_extraction(self, state: PipelineState) -> PipelineState:
         """Bulk pre-extraction of text from documents.  BLOCKING GATE."""

--- a/src/dd_agents/reasoning/contract_graph.py
+++ b/src/dd_agents/reasoning/contract_graph.py
@@ -5,6 +5,11 @@ document relationships, and obligations. Supports queries like:
 - "What happens if Company X triggers a change of control?"
 - "Which contracts have conflicting governing law?"
 - "What's the total liability cap across Customer Y's contracts?"
+
+**Experimental / not wired in**: this is a standalone reasoning primitive.
+No pipeline step, CLI command, or report section constructs it today — see
+docs/knowledge-architecture.md for the wire-in-vs-document-as-experimental
+decision (Issue #258).
 """
 
 from __future__ import annotations

--- a/src/dd_agents/reporting/html_diff.py
+++ b/src/dd_agents/reporting/html_diff.py
@@ -26,9 +26,11 @@ class DiffRenderer(SectionRenderer):
         merged_data: dict[str, Any],
         config: dict[str, Any] | None = None,
         run_dir: Path | None = None,
+        diff_data: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(data, merged_data, config)
         self._run_dir = run_dir
+        self._diff_data = diff_data
 
     def render(self) -> str:
         diff = self._load_diff()
@@ -98,7 +100,9 @@ class DiffRenderer(SectionRenderer):
         return "\n".join(parts)
 
     def _load_diff(self) -> dict[str, Any] | None:
-        """Load report_diff.json from the run directory."""
+        """Return the pre-supplied diff dict, else load report_diff.json from the run directory."""
+        if self._diff_data is not None:
+            return self._diff_data
         if self._run_dir is None:
             return None
         diff_path = self._run_dir / "report" / "report_diff.json"

--- a/src/dd_agents/search/runner.py
+++ b/src/dd_agents/search/runner.py
@@ -43,6 +43,9 @@ class SearchRunner:
         Skip cost confirmation prompt.
     verbose:
         Enable debug logging.
+    as_json:
+        Suppress console chrome/progress and skip the Excel write — the
+        caller (CLI) serializes the returned results as JSON instead.
     """
 
     def __init__(
@@ -55,6 +58,7 @@ class SearchRunner:
         concurrency: int = 5,
         auto_confirm: bool = False,
         verbose: bool = False,
+        as_json: bool = False,
     ) -> None:
         self._prompts_path = prompts_path
         self._data_room = data_room_path.resolve()
@@ -63,6 +67,7 @@ class SearchRunner:
         self._concurrency = concurrency
         self._auto_confirm = auto_confirm
         self._verbose = verbose
+        self._as_json = as_json
 
         # Derive output path from prompts file name if not provided.
         if output_path is not None:
@@ -71,15 +76,20 @@ class SearchRunner:
             stem = prompts_path.stem
             self._output_path = self._data_room / f"search_{stem}.xlsx"
 
-        self._console = Console()
+        self._console = Console(quiet=as_json)
         self._err_console = Console(stderr=True)
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
-    def run(self) -> None:
-        """Execute the full search workflow."""
+    def run(self) -> list[SearchSubjectResult]:
+        """Execute the full search workflow and return the per-subject results.
+
+        Writes the Excel report and prints the console summary unless
+        ``as_json`` was set at construction, in which case both are skipped
+        so the caller can serialize the returned results as JSON.
+        """
         # 1. Load prompts.
         prompts = self._load_prompts()
 
@@ -218,7 +228,7 @@ class SearchRunner:
             confirm = input("Type 'yes' to proceed, or press Enter to cancel: ").strip().lower()
             if confirm not in ("y", "yes"):
                 self._console.print("[yellow]Cancelled.[/yellow]")
-                return
+                return []
 
         # 6. Run analysis with progress bar.
 
@@ -250,6 +260,9 @@ class SearchRunner:
                 len(subjects),
                 len(analyzed),
             )
+
+        if self._as_json:
+            return analyzed
 
         # 8. Write Excel report.
         from dd_agents.search.excel_writer import SearchExcelWriter
@@ -305,6 +318,8 @@ class SearchRunner:
                 border_style="green" if not failures else "yellow",
             )
         )
+
+        return analyzed
 
     # ------------------------------------------------------------------
     # Pipeline integration steps

--- a/src/dd_agents/utils/constants.py
+++ b/src/dd_agents/utils/constants.py
@@ -171,6 +171,15 @@ SHORT_NAME_MAX_LEN = int(os.getenv("DD_SHORT_NAME_MAX_LEN", "5"))  # Never fuzzy
 TFIDF_THRESHOLD = float(os.getenv("DD_TFIDF_THRESHOLD", "0.80"))  # Cosine similarity for TF-IDF
 
 # ---------------------------------------------------------------------------
+# Vector search advisory threshold (Issue #255)
+# ---------------------------------------------------------------------------
+
+# Document count above which optional vector search (pip install dd-agents[vector])
+# starts paying for itself. Advisory only -- crossing it never blocks the
+# pipeline. Override via DD_VECTOR_SEARCH_THRESHOLD.
+VECTOR_SEARCH_DOC_THRESHOLD = int(os.getenv("DD_VECTOR_SEARCH_THRESHOLD", "500"))
+
+# ---------------------------------------------------------------------------
 # Non-subject JSON stems (used by merge and pre-merge validation)
 # ---------------------------------------------------------------------------
 

--- a/tests/e2e/test_discoverability_dx_flow.py
+++ b/tests/e2e/test_discoverability_dx_flow.py
@@ -1,0 +1,74 @@
+"""E2E flow for the Discoverability & DX milestone (issue #269).
+
+Exercises the real user flow end-to-end against the committed Project Atlas
+fixture run -- no API key needed, since every command here is read-only over
+an already-completed run directory. Recorded proof: this test's own pytest
+log (captured by scripts/discoverability-dx-harness.sh gate 6) plus the
+assertions below on each command's actual output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from dd_agents.cli import main
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATLAS_RUN_DIR = (
+    REPO_ROOT
+    / "examples"
+    / "project-atlas"
+    / "sample_data_room"
+    / "_dd"
+    / "forensic-dd"
+    / "runs"
+    / "run_20260606_210024_13c73b"
+)
+
+
+class TestDiffCommandRealFlow:
+    def test_diff_same_run_against_itself_has_no_changes(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["diff", str(ATLAS_RUN_DIR), str(ATLAS_RUN_DIR), "--json"])
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert out["summary"]["new_findings"] == 0
+        assert out["summary"]["resolved_findings"] == 0
+
+    def test_diff_human_summary_mentions_run_ids(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["diff", str(ATLAS_RUN_DIR), str(ATLAS_RUN_DIR)])
+        assert result.exit_code == 0, result.output
+        assert "0" in result.output
+
+
+class TestHealthJsonRealFlow:
+    def test_health_json_over_atlas_knowledge_base(self) -> None:
+        data_room = ATLAS_RUN_DIR.parents[3]  # sample_data_room/
+        runner = CliRunner()
+        result = runner.invoke(main, ["health", "--data-room", str(data_room), "--json"])
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert "total_issues" in out
+        assert "knowledge_base_stats" in out
+
+
+class TestMemoJsonRealFlow:
+    def test_memo_json_over_atlas_run(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["memo", "--report", str(ATLAS_RUN_DIR), "--json"])
+        assert result.exit_code == 0, result.output
+        out = json.loads(result.output)
+        assert "go_no_go" in out
+        assert "top_risks" in out
+
+
+class TestSearchJsonRealFlow:
+    def test_search_json_help_documents_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["search", "--help"])
+        assert result.exit_code == 0, result.output
+        assert "--json" in result.output

--- a/tests/unit/test_cli_json_and_cost.py
+++ b/tests/unit/test_cli_json_and_cost.py
@@ -1,4 +1,4 @@
-"""Tests for --json parity (Issue #241) + the cost reader / assess pre-flight (#246)."""
+"""Tests for --json parity (Issue #241, #256) + the cost reader / assess pre-flight (#246)."""
 
 from __future__ import annotations
 
@@ -146,3 +146,133 @@ class TestCostCommand:
         r = CliRunner().invoke(main, ["cost", str(rd)])
         assert "By Step" in r.output
         assert "Routing:" in r.output
+
+
+class TestHealthJson:
+    def test_health_json_no_knowledge_base(self, tmp_path: Path) -> None:
+        r = CliRunner().invoke(main, ["health", "--data-room", str(tmp_path), "--json"])
+        assert r.exit_code == 0, r.output
+        assert "error" in json.loads(r.output)
+
+    def test_health_json_matches_model_dump(self, tmp_path: Path) -> None:
+        from dd_agents.knowledge.base import DealKnowledgeBase
+
+        kb = DealKnowledgeBase(tmp_path)
+        kb.ensure_dirs()
+
+        r = CliRunner().invoke(main, ["health", "--data-room", str(tmp_path), "--json"])
+        assert r.exit_code == 0, r.output
+        out = json.loads(r.output)
+        assert "total_issues" in out
+        assert "knowledge_base_stats" in out
+
+    def test_health_no_json_prints_console_chrome(self, tmp_path: Path) -> None:
+        from dd_agents.knowledge.base import DealKnowledgeBase
+
+        kb = DealKnowledgeBase(tmp_path)
+        kb.ensure_dirs()
+
+        r = CliRunner().invoke(main, ["health", "--data-room", str(tmp_path)])
+        assert r.exit_code == 0, r.output
+        # Rich panel/table output, not raw JSON.
+        assert not r.output.lstrip().startswith("{")
+
+
+class TestMemoJson:
+    def _run_with_findings(self, tmp_path: Path) -> Path:
+        run = tmp_path / "_dd" / "forensic-dd" / "runs" / "run_x"
+        merged = run / "findings" / "merged"
+        merged.mkdir(parents=True)
+        (merged / "northwind.json").write_text(
+            json.dumps(
+                {
+                    "subject": "Northwind",
+                    "findings": [
+                        {
+                            "title": "CoC auto-termination",
+                            "severity": "P0",
+                            "description": "Customer MSA terminates on change of control.",
+                            "citations": [{"exact_quote": "terminates on change of control", "location": "§12.3"}],
+                        }
+                    ],
+                    "gaps": [],
+                }
+            )
+        )
+        return run
+
+    def test_memo_json_has_go_no_go_and_risks(self, tmp_path: Path) -> None:
+        run = self._run_with_findings(tmp_path)
+        r = CliRunner().invoke(main, ["memo", "--report", str(run), "--json"])
+        assert r.exit_code == 0, r.output
+        out = json.loads(r.output)
+        assert "go_no_go" in out
+        assert "top_risks" in out
+        assert "recommendations" in out
+        assert out["total_findings"] == 1
+
+    def test_memo_json_skips_markdown_html_writes(self, tmp_path: Path) -> None:
+        run = self._run_with_findings(tmp_path)
+        CliRunner().invoke(main, ["memo", "--report", str(run), "--json"])
+        assert not (run / "report" / "ic_memo.md").exists()
+
+    def test_memo_json_missing_findings_emits_error_json(self, tmp_path: Path) -> None:
+        run = tmp_path / "run_empty"
+        (run / "findings" / "merged").mkdir(parents=True)
+        r = CliRunner().invoke(main, ["memo", "--report", str(run), "--json"])
+        assert r.exit_code == 1
+        assert "error" in json.loads(r.output)
+
+
+class TestDiffCommand:
+    def _write_run(self, run_dir: Path, subject: str, findings: list[dict]) -> None:  # type: ignore[type-arg]
+        merged = run_dir / "findings" / "merged"
+        merged.mkdir(parents=True, exist_ok=True)
+        (merged / f"{subject}.json").write_text(
+            json.dumps({"subject": subject, "subject_safe_name": subject, "findings": findings}),
+        )
+        (merged / "gaps").mkdir(exist_ok=True)
+
+    def test_diff_json_reports_new_finding(self, tmp_path: Path) -> None:
+        run_a = tmp_path / "run_a"  # current: has the new finding
+        run_b = tmp_path / "run_b"  # prior: empty
+        self._write_run(run_a, "acme", [{"category": "ip", "citations": [{"source_path": "a.pdf"}]}])
+        self._write_run(run_b, "acme", [])
+
+        r = CliRunner().invoke(main, ["diff", str(run_a), str(run_b), "--json"])
+        assert r.exit_code == 0, r.output
+        out = json.loads(r.output)
+        assert out["summary"]["new_findings"] == 1
+        assert out["summary"]["resolved_findings"] == 0
+        assert out["current_run_id"] == "run_a"
+        assert out["prior_run_id"] == "run_b"
+
+    def test_diff_human_summary_shows_panel(self, tmp_path: Path) -> None:
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        self._write_run(run_a, "acme", [])
+        self._write_run(run_b, "acme", [])
+
+        r = CliRunner().invoke(main, ["diff", str(run_a), str(run_b)])
+        assert r.exit_code == 0, r.output
+        assert "Run Diff" in r.output
+
+    def test_diff_output_writes_standalone_html(self, tmp_path: Path) -> None:
+        run_a = tmp_path / "run_a"
+        run_b = tmp_path / "run_b"
+        self._write_run(run_a, "acme", [{"category": "ip", "citations": [{"source_path": "a.pdf"}]}])
+        self._write_run(run_b, "acme", [])
+        out_html = tmp_path / "diff.html"
+
+        r = CliRunner().invoke(main, ["diff", str(run_a), str(run_b), "--output", str(out_html)])
+        assert r.exit_code == 0, r.output
+        assert out_html.exists()
+        html = out_html.read_text(encoding="utf-8")
+        assert html.startswith("<!DOCTYPE html>")
+        assert "Run-over-Run Changes" in html
+
+    def test_diff_nonexistent_run_dir_errors(self, tmp_path: Path) -> None:
+        run_a = tmp_path / "run_a"
+        self._write_run(run_a, "acme", [])
+        r = CliRunner().invoke(main, ["diff", str(run_a), str(tmp_path / "missing")])
+        assert r.exit_code != 0

--- a/tests/unit/test_dx_harness_isolation.py
+++ b/tests/unit/test_dx_harness_isolation.py
@@ -1,0 +1,70 @@
+"""Multi-instance isolation gate for the Discoverability & DX milestone (issue #269).
+
+Proves Phase-1 rule 1.1: no new module-level mutable state in the `diff`
+command, `ReportDiffBuilder`, or the `--json` paths of `health`/`memo`/`search`.
+Two independent instances/invocations in one process must never leak state.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from dd_agents.cli import main
+from dd_agents.reporting.diff import ReportDiffBuilder
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_run(run_dir: Path, subject: str, findings: list[dict[str, object]]) -> None:
+    merged = run_dir / "findings" / "merged"
+    merged.mkdir(parents=True, exist_ok=True)
+    (merged / f"{subject}.json").write_text(
+        json.dumps({"subject": subject, "subject_safe_name": subject, "findings": findings}),
+        encoding="utf-8",
+    )
+    (merged / "gaps").mkdir(exist_ok=True)
+
+
+class TestReportDiffBuilderIsolation:
+    def test_two_instances_do_not_share_state(self, tmp_path: Path) -> None:
+        run_a = tmp_path / "run_a"  # current: finding resolved (no longer present)
+        run_b = tmp_path / "run_b"  # prior: had the finding
+        run_c = tmp_path / "run_c"
+        _write_run(run_a, "acme", [])
+        _write_run(run_b, "acme", [{"category": "ip", "citations": [{"source_path": "a.pdf"}]}])
+        _write_run(run_c, "acme", [{"category": "ip", "citations": [{"source_path": "a.pdf"}]}])
+
+        builder_1 = ReportDiffBuilder()
+        diff_1 = builder_1.build_diff(run_a / "findings", run_b / "findings")
+
+        builder_2 = ReportDiffBuilder()
+        diff_2 = builder_2.build_diff(run_c / "findings", run_c / "findings")
+
+        # builder_1 found a resolved finding (b -> a); builder_2 diffed identical
+        # runs and must find zero changes -- proves no leakage from builder_1.
+        assert diff_1.summary.resolved_findings == 1
+        assert diff_2.summary.resolved_findings == 0
+        assert diff_2.changes == []
+
+
+class TestCliJsonCommandIsolation:
+    def test_diff_command_invoked_twice_yields_independent_results(self, tmp_path: Path) -> None:
+        run_a = tmp_path / "run_a"  # current: finding resolved
+        run_b = tmp_path / "run_b"  # prior: had the finding
+        _write_run(run_a, "acme", [])
+        _write_run(run_b, "acme", [{"category": "ip", "citations": [{"source_path": "a.pdf"}]}])
+
+        runner = CliRunner()
+        result_1 = runner.invoke(main, ["diff", str(run_a), str(run_b), "--json"])
+        result_2 = runner.invoke(main, ["diff", str(run_a), str(run_a), "--json"])
+
+        assert result_1.exit_code == 0, result_1.output
+        assert result_2.exit_code == 0, result_2.output
+        out_1 = json.loads(result_1.output)
+        out_2 = json.loads(result_2.output)
+        assert out_1["summary"]["resolved_findings"] == 1
+        assert out_2["summary"]["resolved_findings"] == 0

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -4641,3 +4642,57 @@ class TestBuildSourceFindingsLookup:
 
         lookup = engine._build_source_findings_lookup(state)
         assert lookup == {}
+
+
+class TestVectorSearchHint:
+    """Tests for the #255 advisory vector-search hint (issue #269 rule 4.2)."""
+
+    def test_no_warning_under_threshold(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="dd_agents.orchestrator.engine"):
+            PipelineEngine._maybe_warn_vector_search(10)
+        assert "vector-search" not in caplog.text
+
+    def test_warning_over_threshold_without_chromadb(self, caplog: pytest.LogCaptureFixture) -> None:
+        with (
+            patch("dd_agents.vector_store.store.CHROMADB_AVAILABLE", False),
+            caplog.at_level(logging.WARNING, logger="dd_agents.orchestrator.engine"),
+        ):
+            PipelineEngine._maybe_warn_vector_search(501)
+        assert "vector-search" in caplog.text
+        assert "dd-agents[vector]" in caplog.text
+
+    def test_no_warning_over_threshold_with_chromadb_installed(self, caplog: pytest.LogCaptureFixture) -> None:
+        with (
+            patch("dd_agents.vector_store.store.CHROMADB_AVAILABLE", True),
+            caplog.at_level(logging.WARNING, logger="dd_agents.orchestrator.engine"),
+        ):
+            PipelineEngine._maybe_warn_vector_search(501)
+        assert "vector-search" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_step_04_reuses_discovered_count_no_second_walk(self, tmp_path: Path) -> None:
+        """Rule 4.2: the hint must read the count step_04 already computed, not re-walk."""
+        config_path = tmp_path / "deal-config.json"
+        config_path.write_text("{}")
+        engine = PipelineEngine(tmp_path, config_path)
+        run_dir = tmp_path / "runs" / "test_run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        state = PipelineState(run_id="test_run", project_dir=tmp_path, run_dir=run_dir)
+
+        (tmp_path / "a.txt").write_text("x")
+        (tmp_path / "b.txt").write_text("x")
+
+        with (
+            patch.object(PipelineEngine, "_maybe_warn_vector_search") as mock_hint,
+            patch("dd_agents.inventory.discovery.FileDiscovery.discover") as mock_discover,
+        ):
+            from dd_agents.models.inventory import FileEntry
+
+            mock_discover.return_value = [
+                FileEntry(path="a.txt", size=1, mtime=0.0, mtime_iso=""),
+                FileEntry(path="b.txt", size=1, mtime=0.0, mtime_iso=""),
+            ]
+            await engine._step_04_file_discovery(state)
+
+        mock_discover.assert_called_once()
+        mock_hint.assert_called_once_with(2)

--- a/tests/unit/test_search_cli.py
+++ b/tests/unit/test_search_cli.py
@@ -70,8 +70,50 @@ class TestSearchCLI:
         data_room.mkdir()
 
         with patch("dd_agents.search.runner.SearchRunner.run") as mock_run:
+            mock_run.return_value = []
             result = runner.invoke(main, ["search", str(prompts_path), "--data-room", str(data_room)])
 
         # The command should call SearchRunner.run.
         assert mock_run.called
         assert result.exit_code == 0
+
+    def test_json_flag_serializes_runner_results(self, tmp_path: Path) -> None:
+        """--json prints the SearchSubjectResult list SearchRunner.run returns, verbatim."""
+        from dd_agents.models.search import SearchColumnResult, SearchSubjectResult
+
+        runner = CliRunner()
+        prompts_path = _write_prompts_file(tmp_path)
+        data_room = tmp_path / "dr"
+        data_room.mkdir()
+
+        canned_result = SearchSubjectResult(
+            subject_name="Acme Corp",
+            group="Commercial",
+            files_analyzed=2,
+            total_files=2,
+            columns={"Q1": SearchColumnResult(answer="YES", confidence="high")},
+        )
+
+        with patch("dd_agents.search.runner.SearchRunner.run") as mock_run:
+            mock_run.return_value = [canned_result]
+            result = runner.invoke(main, ["search", str(prompts_path), "--data-room", str(data_room), "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload == [canned_result.model_dump()]
+
+    def test_json_flag_passed_through_to_runner(self, tmp_path: Path) -> None:
+        """--json must reach SearchRunner's constructor, not just the CLI layer."""
+        runner = CliRunner()
+        prompts_path = _write_prompts_file(tmp_path)
+        data_room = tmp_path / "dr"
+        data_room.mkdir()
+
+        with (
+            patch("dd_agents.search.runner.SearchRunner.run", return_value=[]),
+            patch("dd_agents.search.runner.SearchRunner.__init__", return_value=None) as mock_init,
+        ):
+            result = runner.invoke(main, ["search", str(prompts_path), "--data-room", str(data_room), "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_init.call_args.kwargs["as_json"] is True


### PR DESCRIPTION
## Summary

Implements the "Roadmap: Discoverability & DX" milestone per spec issue #269:

- **#256**: `--json` on `health`, `memo`, `search` CLI commands (mirrors existing `query`/`assess` convention)
- **#257**: new `dd-agents diff <run_a> <run_b>` command reusing `ReportDiffBuilder.build_diff` (no shadow diff logic)
- **#254**: documents already-shipped transcription (`extraction/transcribe.py`) and clause library (`reporting/clause_library.py`) — pure docs gap, no code change
- **#255**: docs cross-referencing the 500-document vector-search threshold + an advisory-only runtime hint (`_maybe_warn_vector_search`) that reuses the file count `_step_04_file_discovery` already computed — no second filesystem walk, never blocks the pipeline
- **#258**: documents `ContractKnowledgeGraph` as an experimental, non-wired reasoning primitive (docstring + `knowledge-architecture.md` decision entry) rather than wiring it into a query surface

Adds `scripts/discoverability-dx-harness.sh` as a permanent, committed regression gate for this area (6 independent gates: lint, SAST, multi-instance isolation, dead-code scan, unit/integration tests + mypy --strict, E2E).

## Gate-by-gate result (final run against this diff)

| Gate | Check | Result |
|------|-------|--------|
| 1 | Lint (`ruff check src/ tests/`) | ✅ All checks passed |
| 2 | SAST (`bandit -r src/dd_agents -ll`) | ✅ Zero findings |
| 3 | Multi-instance isolation | ✅ 2 passed |
| 4 | Dead-code scan (vulture, diffed vs. baseline) | ✅ No new findings |
| 5 | Unit/integration tests + `mypy --strict` | ✅ 4444 passed; no type issues in 227 source files |
| 6 | E2E flow (no API key needed) | ✅ 5 passed |

## Deviation from spec #269

Gate 4's dead-code baseline originally matched on exact line numbers, which false-failed when unrelated edits shifted a pre-existing finding's line. Fixed by normalizing both the baseline and the comparison to match on file+message only.

Closes #254, #255, #256, #257, #258, #269

## Test plan

- [x] `pytest tests/unit/ -x -q` — 4444 passed
- [x] `mypy src/ --strict` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `bash scripts/discoverability-dx-harness.sh` — all 6 gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)